### PR TITLE
Feat[MD-69]: Implementar logs contextuales con IDs de petición

### DIFF
--- a/backend/src/modules/repository_documents/application/commands/upload-document.usecase.ts
+++ b/backend/src/modules/repository_documents/application/commands/upload-document.usecase.ts
@@ -5,6 +5,7 @@ import type { DocumentStoragePort } from '../../domain/ports/document-storage.po
 import type { DocumentRepositoryPort } from '../../domain/ports/document-repository.port';
 import { Document } from '../../domain/entities/document.entity';
 import { UploadDocumentRequest } from '../../domain/value-objects/upload-document.vo';
+import { url } from 'inspector';
 
 @Injectable()
 export class UploadDocumentUseCase {
@@ -17,6 +18,15 @@ export class UploadDocumentUseCase {
     file: Express.Multer.File,
     uploadedBy: string,
   ): Promise<Document> {
+    console.log(' Starting upload use case:', {
+      fileName: file.originalname,
+      mimeType: file.mimetype,
+      size: file.size,
+      uploadedBy,
+      hasBuffer: !!file.buffer,
+      bufferLength: file.buffer?.length,
+    });
+
     // Validar que sea un PDF
     if (file.mimetype !== 'application/pdf') {
       throw new BadRequestException('Solo se permiten archivos PDF');
@@ -29,7 +39,6 @@ export class UploadDocumentUseCase {
 
     // Generar hash SHA-256 del archivo
     const fileHash = this.generateFileHash(file.buffer);
-
     // Verificar si ya existe un archivo con el mismo hash
     const existingDocument =
       await this.documentRepository.findByFileHash(fileHash);
@@ -48,26 +57,32 @@ export class UploadDocumentUseCase {
       file.size,
     );
 
-    const storageResult =
-      await this.storageAdapter.uploadDocument(uploadRequest);
+    try {
+      const storageResult =
+        await this.storageAdapter.uploadDocument(uploadRequest);
 
-    // Crear entidad de documento para base de datos
-    const document = Document.create(
-      documentId,
-      storageResult.fileName, // storedName
-      file.originalname, // originalName
-      file.mimetype,
-      file.size,
-      storageResult.url,
-      storageResult.fileName, // s3Key (mismo que fileName en este caso)
-      fileHash,
-      uploadedBy,
-    );
+      // Crear entidad de documento para base de datos
+      console.log(' Creating document entity...');
+      const document = Document.create(
+        documentId,
+        storageResult.fileName, // storedName
+        file.originalname, // originalName
+        file.mimetype,
+        file.size,
+        storageResult.url,
+        storageResult.fileName, // s3Key (mismo que fileName en este caso)
+        fileHash,
+        uploadedBy,
+      );
 
-    // Guardar en base de datos
-    const savedDocument = await this.documentRepository.save(document);
+      // Guardar en base de datos
+      const savedDocument = await this.documentRepository.save(document);
 
-    return savedDocument;
+      return savedDocument;
+    } catch (error) {
+      console.log(' Upload failed:', error);
+      throw error;
+    }
   }
 
   /**

--- a/backend/src/modules/repository_documents/documents.module.ts
+++ b/backend/src/modules/repository_documents/documents.module.ts
@@ -245,5 +245,9 @@ export class DocumentsModule implements NestModule {
     consumer
       .apply(LoggingMiddleware)
       .forRoutes('api/documents', 'api/repository-documents/embeddings');
+
+    consumer
+      .apply(AuthMiddleware)
+      .forRoutes({ path: 'api/documents/upload', method: RequestMethod.POST });
   }
 }

--- a/backend/src/modules/repository_documents/documents.module.ts
+++ b/backend/src/modules/repository_documents/documents.module.ts
@@ -47,12 +47,17 @@ import { GenerateDocumentEmbeddingsUseCase } from './application/use-cases/gener
 import { SearchDocumentsUseCase } from './application/use-cases/search-documents.use-case';
 import { NestModule, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
 import { AuthMiddleware } from './infrastructure/http/middleware/auth.middleware';
+import { LoggingMiddleware } from './infrastructure/http/middleware/logging.middleware';
+import { ContextualLoggerService } from './infrastructure/services/contextual-logger.service';
 @Module({
   imports: [PrismaModule, IdentityModule],
   controllers: [DocumentsController, EmbeddingsController],
   providers: [
     // Servicios de configuración
     AiConfigService,
+
+    // Servicios de logging
+    ContextualLoggerService,
 
     // Infrastructure adapters
     { provide: DOCUMENT_STORAGE_PORT, useClass: S3StorageAdapter },
@@ -238,7 +243,7 @@ import { AuthMiddleware } from './infrastructure/http/middleware/auth.middleware
 export class DocumentsModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(AuthMiddleware)
-      .forRoutes({ path: 'api/documents/upload', method: RequestMethod.POST });
+      .apply(LoggingMiddleware)
+      .forRoutes('api/documents', 'api/repository-documents/embeddings');
   }
 }

--- a/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
@@ -16,6 +16,7 @@ import {
 import { Request } from 'express';
 import type { AuthenticatedRequest } from '../http/middleware/auth.middleware';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ContextualLoggerService } from '../services/contextual-logger.service';
 import { ListDocumentsUseCase } from '../../application/queries/list-documents.usecase';
 import { DeleteDocumentUseCase } from '../../application/commands/delete-document.usecase';
 import { UploadDocumentUseCase } from '../../application/commands/upload-document.usecase';
@@ -41,11 +42,14 @@ export class DocumentsController {
     private readonly downloadDocumentUseCase: DownloadDocumentUseCase,
     private readonly processDocumentTextUseCase: ProcessDocumentTextUseCase,
     private readonly processDocumentChunksUseCase: ProcessDocumentChunksUseCase,
+    private readonly logger: ContextualLoggerService,
   ) {}
 
   @Get()
   async listDocuments(): Promise<DocumentListResponseDto> {
     try {
+      this.logger.logDocumentOperation('list');
+      
       const result = await this.listDocumentsUseCase.execute();
 
       // Mapear la respuesta del dominio a DTOs
@@ -62,6 +66,11 @@ export class DocumentsController {
           ),
       );
 
+      this.logger.log('Documents retrieved successfully', {
+        totalDocuments: result.total,
+        documentsReturned: documents.length,
+      });
+
       return new DocumentListResponseDto(
         documents,
         result.total,
@@ -70,6 +79,10 @@ export class DocumentsController {
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
+
+      this.logger.error('Error retrieving documents', error instanceof Error ? error : errorMessage, {
+        errorType: 'DOCUMENTS_LIST_ERROR',
+      });
 
       // Manejar diferentes tipos de errores
       if (errorMessage.includes('Bucket de documentos no encontrado')) {
@@ -114,11 +127,18 @@ export class DocumentsController {
     @Param('id') documentId: string,
   ): Promise<DeleteDocumentResponseDto> {
     try {
+      this.logger.logDocumentOperation('delete', documentId);
+      
       const result = await this.deleteDocumentUseCase.execute(documentId);
 
       if (!result.success) {
         // Documento no encontrado
         if (result.error === 'DOCUMENT_NOT_FOUND') {
+          this.logger.warn('Document not found for deletion', {
+            documentId,
+            errorType: 'DOCUMENT_NOT_FOUND',
+          });
+          
           throw new HttpException(
             new DeleteDocumentErrorDto(
               'Document Not Found',
@@ -130,6 +150,11 @@ export class DocumentsController {
         }
 
         // Otros errores
+        this.logger.error('Document deletion failed', result.message, {
+          documentId,
+          errorType: result.error,
+        });
+        
         throw new HttpException(
           new DeleteDocumentErrorDto(
             'Delete Failed',
@@ -139,6 +164,11 @@ export class DocumentsController {
           HttpStatus.INTERNAL_SERVER_ERROR,
         );
       }
+
+      this.logger.log('Document deleted successfully', {
+        documentId,
+        deletedAt: result.deletedAt,
+      });
 
       return new DeleteDocumentResponseDto(
         result.message,
@@ -154,7 +184,11 @@ export class DocumentsController {
       // Error inesperado
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in deleteDocument:', errorMessage);
+      
+      this.logger.error('Unexpected error in deleteDocument', error instanceof Error ? error : errorMessage, {
+        documentId,
+        errorType: 'UNEXPECTED_ERROR',
+      });
 
       throw new HttpException(
         new DeleteDocumentErrorDto(
@@ -183,7 +217,21 @@ export class DocumentsController {
         throw new BadRequestException('Usuario no autenticado');
       }
 
+      this.logger.setContext({ userId });
+      this.logger.logDocumentOperation('upload', undefined, {
+        fileName: file.originalname,
+        fileSize: file.size,
+        mimeType: file.mimetype,
+      });
+
       const document = await this.uploadDocumentUseCase.execute(file, userId);
+
+      this.logger.log('Document uploaded successfully', {
+        documentId: document.id,
+        fileName: document.fileName,
+        originalName: document.originalName,
+        size: document.size,
+      });
 
       return {
         id: document.id,
@@ -205,7 +253,12 @@ export class DocumentsController {
       // Error inesperado
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in uploadDocument:', errorMessage);
+      
+      this.logger.error('Unexpected error in uploadDocument', error instanceof Error ? error : errorMessage, {
+        fileName: file?.originalname,
+        fileSize: file?.size,
+        errorType: 'UPLOAD_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -230,8 +283,16 @@ export class DocumentsController {
         );
       }
 
+      this.logger.logDocumentOperation('download', documentId);
+
       const downloadUrl =
         await this.downloadDocumentUseCase.execute(documentId);
+      
+      this.logger.log('Document download URL generated successfully', {
+        documentId,
+        downloadUrlLength: downloadUrl.length,
+      });
+      
       return { downloadUrl };
     } catch (error) {
       if (
@@ -240,9 +301,14 @@ export class DocumentsController {
       ) {
         throw error;
       }
+      
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in downloadDocument:', errorMessage);
+      
+      this.logger.error('Unexpected error in downloadDocument', error instanceof Error ? error : errorMessage, {
+        documentId,
+        errorType: 'DOWNLOAD_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -261,14 +327,28 @@ export class DocumentsController {
     @Param('documentId') documentId: string,
   ): Promise<{ message: string; success: boolean }> {
     try {
+      this.logger.logDocumentOperation('process', documentId, {
+        operation: 'text_extraction',
+      });
+
       const success = await this.processDocumentTextUseCase.execute(documentId);
 
       if (success) {
+        this.logger.log('Document text processed successfully', {
+          documentId,
+          operation: 'text_extraction',
+        });
+        
         return {
           success: true,
           message: 'Texto extraído exitosamente del documento',
         };
       } else {
+        this.logger.warn('Document text processing failed', {
+          documentId,
+          operation: 'text_extraction',
+        });
+        
         throw new HttpException(
           {
             statusCode: HttpStatus.BAD_REQUEST,
@@ -285,7 +365,12 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in processDocumentText:', errorMessage);
+      
+      this.logger.error('Unexpected error in processDocumentText', error instanceof Error ? error : errorMessage, {
+        documentId,
+        operation: 'text_extraction',
+        errorType: 'PROCESSING_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -323,6 +408,12 @@ export class DocumentsController {
         throw new BadRequestException('ID de documento requerido');
       }
 
+      this.logger.logChunkOperation('process', documentId, undefined, {
+        chunkingConfig: body.chunkingConfig,
+        replaceExisting: body.replaceExisting,
+        chunkType: body.chunkType,
+      });
+
       const result = await this.processDocumentChunksUseCase.execute({
         documentId,
         chunkingConfig: body.chunkingConfig,
@@ -331,6 +422,11 @@ export class DocumentsController {
       });
 
       if (result.status === 'success') {
+        this.logger.logChunkOperation('process', documentId, result.savedChunks.length, {
+          processingTimeMs: result.processingTimeMs,
+          statistics: result.chunkingResult.statistics,
+        });
+        
         return {
           success: true,
           message: 'Chunks procesados exitosamente',
@@ -341,6 +437,12 @@ export class DocumentsController {
           },
         };
       } else {
+        this.logger.error('Chunk processing failed', JSON.stringify(result.errors), {
+          documentId,
+          operation: 'chunk_processing',
+          errors: result.errors,
+        });
+        
         return {
           success: false,
           message: 'Error procesando chunks',
@@ -357,7 +459,12 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in processDocumentChunks:', errorMessage);
+      
+      this.logger.error('Unexpected error in processDocumentChunks', error instanceof Error ? error : errorMessage, {
+        documentId,
+        operation: 'chunk_processing',
+        errorType: 'CHUNK_PROCESSING_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -385,11 +492,20 @@ export class DocumentsController {
         throw new BadRequestException('ID de documento requerido');
       }
 
+      this.logger.logChunkOperation('retrieve', documentId);
+
       // Usar el servicio de chunking para obtener chunks con estadísticas
       const result =
         await this.processDocumentChunksUseCase[
           'chunkingService'
         ].getDocumentChunks(documentId);
+
+      this.logger.log('Document chunks retrieved successfully', {
+        documentId,
+        totalChunks: result.total,
+        chunksReturned: result.chunks.length,
+        statistics: result.statistics,
+      });
 
       return {
         success: true,
@@ -420,7 +536,12 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in getDocumentChunks:', errorMessage);
+      
+      this.logger.error('Unexpected error in getDocumentChunks', error instanceof Error ? error : errorMessage, {
+        documentId,
+        operation: 'chunk_retrieval',
+        errorType: 'CHUNK_RETRIEVAL_ERROR',
+      });
 
       throw new HttpException(
         {

--- a/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
@@ -208,6 +208,19 @@ export class DocumentsController {
     @Req() req: AuthenticatedRequest,
   ): Promise<UploadDocumentResponseDto> {
     try {
+      console.log(' Upload request received:', {
+        hasFile: !!file,
+        fileInfo: file ? {
+          originalname: file.originalname,
+          size: file.size,
+          mimetype: file.mimetype,
+          fieldname: file.fieldname,
+        } : null,
+        hasUser: !!req.user,
+        userId: req.user?.id,
+        headers: req.headers,
+      });
+
       if (!file) {
         throw new BadRequestException('No se ha proporcionado ningún archivo');
       }

--- a/backend/src/modules/repository_documents/infrastructure/http/embeddings.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/embeddings.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiBody,
 } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator';
+import { ContextualLoggerService } from '../services/contextual-logger.service';
 import { GenerateDocumentEmbeddingsUseCase } from '../../application/use-cases/generate-document-embeddings.use-case';
 import { SearchDocumentsUseCase } from '../../application/use-cases/search-documents.use-case';
 
@@ -87,6 +88,7 @@ export class EmbeddingsController {
   constructor(
     private readonly generateEmbeddingsUseCase: GenerateDocumentEmbeddingsUseCase,
     private readonly searchDocumentsUseCase: SearchDocumentsUseCase,
+    private readonly contextualLogger: ContextualLoggerService,
   ) {}
 
   /**
@@ -176,7 +178,7 @@ export class EmbeddingsController {
   ) {
     try {
       this.logger.log(
-        `🚀 Iniciando generación de embeddings para documento: ${documentId}`,
+        ` Iniciando generación de embeddings para documento: ${documentId}`,
       );
       const startTime = Date.now();
 
@@ -311,10 +313,10 @@ export class EmbeddingsController {
   async searchDocuments(@Body() dto: SemanticSearchDto) {
     try {
       // Debug: Ver qué está llegando
-      this.logger.log(`📨 DTO recibido:`, JSON.stringify(dto, null, 2));
-      this.logger.log(`📊 Tipo de dto:`, typeof dto);
-      this.logger.log(`📊 Tipo de query:`, typeof dto?.query);
-      this.logger.log(`📊 Query value:`, dto?.query);
+      this.logger.log(` DTO recibido:`, JSON.stringify(dto, null, 2));
+      this.logger.log(` Tipo de dto:`, typeof dto);
+      this.logger.log(` Tipo de query:`, typeof dto?.query);
+      this.logger.log(` Query value:`, dto?.query);
 
       // Validación adicional de entrada
       if (!dto || !dto.query || typeof dto.query !== 'string') {
@@ -359,7 +361,7 @@ export class EmbeddingsController {
       }
 
       this.logger.log(
-        `✅ Búsqueda completada: ${result.result?.totalResults || 0} resultados en ${processingTime}ms`,
+        ` Búsqueda completada: ${result.result?.totalResults || 0} resultados en ${processingTime}ms`,
       );
 
       return {

--- a/backend/src/modules/repository_documents/infrastructure/http/middleware/logging.middleware.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/middleware/logging.middleware.ts
@@ -1,0 +1,73 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface LoggingRequest extends Request {
+  requestId?: string;
+  startTime?: number;
+}
+
+@Injectable()
+export class LoggingMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('DocumentsAPI');
+
+  use(req: LoggingRequest, res: Response, next: NextFunction) {
+    // Generar ID único para la petición
+    req.requestId = uuidv4();
+    req.startTime = Date.now();
+
+    // Log de inicio de petición
+    this.logger.log(
+      `[${req.requestId}] ${req.method} ${req.url} - Request started`,
+      {
+        requestId: req.requestId,
+        method: req.method,
+        url: req.url,
+        userAgent: req.headers['user-agent'],
+        ip: req.ip,
+        timestamp: new Date().toISOString(),
+      },
+    );
+
+    // Interceptar la respuesta para loggear el final
+    const originalSend = res.send;
+    res.send = function (body: any) {
+      const duration = Date.now() - (req.startTime || 0);
+      
+      const logLevel = res.statusCode >= 400 ? 'error' : 'log';
+      const logMessage = `[${req.requestId}] ${req.method} ${req.url} - ${res.statusCode} - ${duration}ms`;
+      
+      if (logLevel === 'error') {
+        Logger.prototype.error.call(
+          new Logger('DocumentsAPI'),
+          logMessage,
+          {
+            requestId: req.requestId,
+            method: req.method,
+            url: req.url,
+            statusCode: res.statusCode,
+            duration,
+            timestamp: new Date().toISOString(),
+          },
+        );
+      } else {
+        Logger.prototype.log.call(
+          new Logger('DocumentsAPI'),
+          logMessage,
+          {
+            requestId: req.requestId,
+            method: req.method,
+            url: req.url,
+            statusCode: res.statusCode,
+            duration,
+            timestamp: new Date().toISOString(),
+          },
+        );
+      }
+
+      return originalSend.call(this, body);
+    };
+
+    next();
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/services/contextual-logger.service.ts
+++ b/backend/src/modules/repository_documents/infrastructure/services/contextual-logger.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger, Scope, Inject } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import type { LoggingRequest } from '../http/middleware/logging.middleware';
+
+export interface LogContext {
+  requestId?: string;
+  userId?: string;
+  action?: string;
+  resource?: string;
+  metadata?: Record<string, any>;
+}
+
+@Injectable({ scope: Scope.REQUEST })
+export class ContextualLoggerService {
+  private readonly logger = new Logger('DocumentsService');
+  private context: LogContext = {};
+
+  constructor(@Inject(REQUEST) private request: LoggingRequest) {
+    // Extraer requestId del request
+    this.context.requestId = this.request.requestId;
+  }
+
+  setContext(context: Partial<LogContext>) {
+    this.context = { ...this.context, ...context };
+  }
+
+  private formatMessage(message: string, additionalContext?: Record<string, any>) {
+    const fullContext = {
+      ...this.context,
+      ...additionalContext,
+      timestamp: new Date().toISOString(),
+    };
+
+    const contextStr = this.context.requestId 
+      ? `[${this.context.requestId}]` 
+      : '';
+
+    return {
+      message: `${contextStr} ${message}`,
+      context: fullContext,
+    };
+  }
+
+  log(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.log(formatted.message, formatted.context);
+  }
+
+  error(message: string, error?: Error | string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, {
+      ...context,
+      error: error instanceof Error ? {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      } : error,
+    });
+    this.logger.error(formatted.message, formatted.context);
+  }
+
+  warn(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.warn(formatted.message, formatted.context);
+  }
+
+  debug(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.debug(formatted.message, formatted.context);
+  }
+
+  verbose(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.verbose(formatted.message, formatted.context);
+  }
+
+  // Métodos específicos para el dominio de documentos
+  logDocumentOperation(
+    operation: 'upload' | 'download' | 'delete' | 'process' | 'list',
+    documentId?: string,
+    additionalContext?: Record<string, any>
+  ) {
+    this.setContext({
+      action: operation,
+      resource: 'document',
+      metadata: { documentId, ...additionalContext },
+    });
+    
+    this.log(`Document ${operation} operation`, {
+      documentId,
+      ...additionalContext,
+    });
+  }
+
+  logChunkOperation(
+    operation: 'create' | 'process' | 'retrieve',
+    documentId: string,
+    chunkCount?: number,
+    additionalContext?: Record<string, any>
+  ) {
+    this.setContext({
+      action: `chunk_${operation}`,
+      resource: 'document_chunk',
+      metadata: { documentId, chunkCount, ...additionalContext },
+    });
+
+    this.log(`Chunk ${operation} operation for document`, {
+      documentId,
+      chunkCount,
+      ...additionalContext,
+    });
+  }
+
+  logEmbeddingOperation(
+    operation: 'generate' | 'search',
+    documentId?: string,
+    additionalContext?: Record<string, any>
+  ) {
+    this.setContext({
+      action: `embedding_${operation}`,
+      resource: 'embedding',
+      metadata: { documentId, ...additionalContext },
+    });
+
+    this.log(`Embedding ${operation} operation`, {
+      documentId,
+      ...additionalContext,
+    });
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/storage/S3-storage.adapter.ts
+++ b/backend/src/modules/repository_documents/infrastructure/storage/S3-storage.adapter.ts
@@ -47,6 +47,17 @@ export class S3StorageAdapter implements DocumentStoragePort {
    */
   async uploadDocument(req: UploadDocumentRequest): Promise<Document> {
     try {
+      console.log(' MinIO Config:', {
+        endpoint: this.endpoint,
+        bucketName: this.bucketName,
+        region: minioConfig.region,
+      });
+      console.log(' Upload Request:', {
+        originalName: req.originalName,
+        mimeType: req.mimeType,
+        size: req.size,
+      });
+      
       // Generar nombre único para el archivo
       const fileName = this.generateFileName(req.originalName);
 
@@ -80,8 +91,8 @@ export class S3StorageAdapter implements DocumentStoragePort {
       );
 
       return document;
-    } catch {
-      throw new Error('Error uploading document to MinIO');
+    } catch (error) {
+      throw new Error(`Error uploading document to MinIO: ${error.message || error}`);
     }
   }
 
@@ -103,8 +114,8 @@ export class S3StorageAdapter implements DocumentStoragePort {
       });
 
       return signedUrl;
-    } catch {
-      throw new Error('Error generating download URL');
+    } catch (error) {
+      throw new Error(`Error generating download URL: ${error.message || error}`);
     }
   }
 

--- a/infra/docker/.env
+++ b/infra/docker/.env
@@ -2,7 +2,7 @@ POSTGRES_USER=app_user
 POSTGRES_PASSWORD=app_pass
 POSTGRES_DB=learning_agent
 
-MINIO_ENDPOINT=http://localhost:9090
+MINIO_ENDPOINT=http://localhost:9000
 MINIO_ROOT_USER=adminminio
 MINIO_ROOT_PASSWORD=adminpassword
 MINIO_BUCKET_NAME=documents

--- a/infra/docker/.gitignore
+++ b/infra/docker/.gitignore
@@ -1,1 +1,3 @@
 minio-data/
+minio-data/*
+**/minio-data/

--- a/infra/docker/minio.compose.yml
+++ b/infra/docker/minio.compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   minio:
     image: quay.io/minio/minio:latest
@@ -7,8 +6,7 @@ services:
       - "9000:9000"
       - "9090:9090"
     volumes:
-      - /tmp/data:/data
-      - ./minio-data:/data
+      - minio-data:/data
     env_file:
       - .env
     command: server /data --console-address ":9090"
@@ -17,25 +15,38 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    networks:
+      - minio-network
 
   create-bucket:
     image: minio/mc
     container_name: minio-create-bucket
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     env_file:
       - .env
     entrypoint: >
       /bin/sh -c "
       echo 'Waiting for MinIO to be ready...';
-      sleep 10;
-      echo 'Configuring MinIO client...';
-      /usr/bin/mc alias set myminio http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD;
-      echo 'Creating documents bucket...';
+      until /usr/bin/mc alias set myminio http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD; do
+        echo 'MinIO not ready yet, waiting...';
+        sleep 5;
+      done;
+      echo 'MinIO is ready, creating bucket...';
       /usr/bin/mc mb myminio/documents --ignore-existing;
       echo 'Setting bucket policy to public read...';
       /usr/bin/mc anonymous set download myminio/documents;
       echo 'Bucket created and configured successfully!';
-      exit 0;
       "
     restart: "no"
+    networks:
+      - minio-network
+
+volumes:
+  minio-data:
+    driver: local
+
+networks:
+  minio-network:
+    driver: bridge


### PR DESCRIPTION
### ✨ Main Implementations

* **Logging Middleware (`logging.middleware.ts`):** A new middleware has been created that generates a unique ID (UUID) for each request. It captures the start and end of the request, as well as the client's IP and User-Agent.
* **Contextual Logger Service (`contextual-logger.service.ts`):** A service was implemented that automatically injects the request ID into all logs generated during that request's lifecycle, allowing for clear operational tracking.
* **Integration into Documents Controller:** All methods in `documents.controller.ts` now use the contextual logger for better visibility and debugging of the file upload process.
* **Authentication on Upload Endpoint:** The `api/documents/upload` route has been protected with `AuthMiddleware`, ensuring that only authenticated users can upload documents.

---
### 🔧 Additional Improvements & Fixes

* **Improved Error Handling:** The `S3StorageAdapter` has been enhanced to include more detailed error messages in exceptions for both file uploads and URL generation failures.
* **Optimized Docker/MinIO Configuration:**
    * Switched to a **named volume** (`minio-data`) for better persistence management.
    * Added a custom network (`minio-network`) for MinIO services.
    * The bucket creation script now waits for MinIO to be fully ready, preventing startup errors.
* **Updated `.gitignore`** to correctly exclude MinIO data directories.

### 🧪 Steps to Test

1.  Ensure Docker containers (especially the database and MinIO) are running.
2.  Start the backend with `npm run start`.
3.  In Postman (or a similar tool), first obtain an authentication token for a user.
4.  Make a **POST** request to `localhost:3000/api/documents/upload`.
5.  In the **Headers**, add the authorization with the obtained token.
6.  In the **Body** (form-data), add a field of type `File` with the key `file` and select a PDF file.
7.  Send the request.
8.  **Verification:**
    * The request should return a `201 Created` status.
    * In the backend console, all logs related to that request should display the same unique request ID.


<img width="722" height="529" alt="image" src="https://github.com/user-attachments/assets/6b1110a5-0827-4ee8-b8e2-f86bbfccbc84" />

<img width="707" height="387" alt="image" src="https://github.com/user-attachments/assets/377b06ac-da75-4ae3-bc6a-2e63a81539da" />

<img width="727" height="363" alt="image" src="https://github.com/user-attachments/assets/96f1f3e6-0003-4a0a-a4b8-fc7a9e5544f9" />
