### PR TITLE
Feat[MD-93]: Increase the maximum allowed PDF file size to 100MB

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,9 +2,14 @@ import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DomainErrorFilter } from 'src/core/prisma/http/domain-error.filter';
+import * as express from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Configurar límites para archivos grandes
+  app.use(express.json({ limit: '100mb' }));
+  app.use(express.urlencoded({ limit: '100mb', extended: true }));
 
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.useGlobalFilters(new DomainErrorFilter()); // Handle DomainError globally,(en el futuro el dominio lanza DomainErrors)

--- a/backend/src/modules/repository_documents/application/commands/upload-document.usecase.ts
+++ b/backend/src/modules/repository_documents/application/commands/upload-document.usecase.ts
@@ -32,9 +32,9 @@ export class UploadDocumentUseCase {
       throw new BadRequestException('Solo se permiten archivos PDF');
     }
 
-    const maxSize = 10 * 1024 * 1024; // 10MB en bytes
+    const maxSize = 100 * 1024 * 1024; // 100MB en bytes
     if (file.size > maxSize) {
-      throw new BadRequestException('El archivo no puede ser mayor a 10MB');
+      throw new BadRequestException('El archivo no puede ser mayor a 100MB');
     }
 
     // Generar hash SHA-256 del archivo

--- a/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
@@ -16,6 +16,7 @@ import {
 import { Request } from 'express';
 import type { AuthenticatedRequest } from '../http/middleware/auth.middleware';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 import { ContextualLoggerService } from '../services/contextual-logger.service';
 import { ListDocumentsUseCase } from '../../application/queries/list-documents.usecase';
 import { DeleteDocumentUseCase } from '../../application/commands/delete-document.usecase';
@@ -49,7 +50,7 @@ export class DocumentsController {
   async listDocuments(): Promise<DocumentListResponseDto> {
     try {
       this.logger.logDocumentOperation('list');
-      
+
       const result = await this.listDocumentsUseCase.execute();
 
       // Mapear la respuesta del dominio a DTOs
@@ -80,9 +81,13 @@ export class DocumentsController {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
 
-      this.logger.error('Error retrieving documents', error instanceof Error ? error : errorMessage, {
-        errorType: 'DOCUMENTS_LIST_ERROR',
-      });
+      this.logger.error(
+        'Error retrieving documents',
+        error instanceof Error ? error : errorMessage,
+        {
+          errorType: 'DOCUMENTS_LIST_ERROR',
+        },
+      );
 
       // Manejar diferentes tipos de errores
       if (errorMessage.includes('Bucket de documentos no encontrado')) {
@@ -128,7 +133,7 @@ export class DocumentsController {
   ): Promise<DeleteDocumentResponseDto> {
     try {
       this.logger.logDocumentOperation('delete', documentId);
-      
+
       const result = await this.deleteDocumentUseCase.execute(documentId);
 
       if (!result.success) {
@@ -138,7 +143,7 @@ export class DocumentsController {
             documentId,
             errorType: 'DOCUMENT_NOT_FOUND',
           });
-          
+
           throw new HttpException(
             new DeleteDocumentErrorDto(
               'Document Not Found',
@@ -154,7 +159,7 @@ export class DocumentsController {
           documentId,
           errorType: result.error,
         });
-        
+
         throw new HttpException(
           new DeleteDocumentErrorDto(
             'Delete Failed',
@@ -184,11 +189,15 @@ export class DocumentsController {
       // Error inesperado
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      
-      this.logger.error('Unexpected error in deleteDocument', error instanceof Error ? error : errorMessage, {
-        documentId,
-        errorType: 'UNEXPECTED_ERROR',
-      });
+
+      this.logger.error(
+        'Unexpected error in deleteDocument',
+        error instanceof Error ? error : errorMessage,
+        {
+          documentId,
+          errorType: 'UNEXPECTED_ERROR',
+        },
+      );
 
       throw new HttpException(
         new DeleteDocumentErrorDto(
@@ -202,7 +211,24 @@ export class DocumentsController {
   }
 
   @Post('upload')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: {
+        fileSize: 100 * 1024 * 1024, // 100MB en bytes
+      },
+      fileFilter: (req, file, callback) => {
+        if (file.mimetype !== 'application/pdf') {
+          callback(
+            new BadRequestException('Solo se permiten archivos PDF'),
+            false,
+          );
+        } else {
+          callback(null, true);
+        }
+      },
+    }),
+  )
   async uploadDocument(
     @UploadedFile() file: Express.Multer.File,
     @Req() req: AuthenticatedRequest,
@@ -210,12 +236,14 @@ export class DocumentsController {
     try {
       console.log(' Upload request received:', {
         hasFile: !!file,
-        fileInfo: file ? {
-          originalname: file.originalname,
-          size: file.size,
-          mimetype: file.mimetype,
-          fieldname: file.fieldname,
-        } : null,
+        fileInfo: file
+          ? {
+              originalname: file.originalname,
+              size: file.size,
+              mimetype: file.mimetype,
+              fieldname: file.fieldname,
+            }
+          : null,
         hasUser: !!req.user,
         userId: req.user?.id,
         headers: req.headers,
@@ -266,12 +294,16 @@ export class DocumentsController {
       // Error inesperado
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      
-      this.logger.error('Unexpected error in uploadDocument', error instanceof Error ? error : errorMessage, {
-        fileName: file?.originalname,
-        fileSize: file?.size,
-        errorType: 'UPLOAD_ERROR',
-      });
+
+      this.logger.error(
+        'Unexpected error in uploadDocument',
+        error instanceof Error ? error : errorMessage,
+        {
+          fileName: file?.originalname,
+          fileSize: file?.size,
+          errorType: 'UPLOAD_ERROR',
+        },
+      );
 
       throw new HttpException(
         {
@@ -300,12 +332,12 @@ export class DocumentsController {
 
       const downloadUrl =
         await this.downloadDocumentUseCase.execute(documentId);
-      
+
       this.logger.log('Document download URL generated successfully', {
         documentId,
         downloadUrlLength: downloadUrl.length,
       });
-      
+
       return { downloadUrl };
     } catch (error) {
       if (
@@ -314,14 +346,18 @@ export class DocumentsController {
       ) {
         throw error;
       }
-      
+
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      
-      this.logger.error('Unexpected error in downloadDocument', error instanceof Error ? error : errorMessage, {
-        documentId,
-        errorType: 'DOWNLOAD_ERROR',
-      });
+
+      this.logger.error(
+        'Unexpected error in downloadDocument',
+        error instanceof Error ? error : errorMessage,
+        {
+          documentId,
+          errorType: 'DOWNLOAD_ERROR',
+        },
+      );
 
       throw new HttpException(
         {
@@ -351,7 +387,7 @@ export class DocumentsController {
           documentId,
           operation: 'text_extraction',
         });
-        
+
         return {
           success: true,
           message: 'Texto extraído exitosamente del documento',
@@ -361,7 +397,7 @@ export class DocumentsController {
           documentId,
           operation: 'text_extraction',
         });
-        
+
         throw new HttpException(
           {
             statusCode: HttpStatus.BAD_REQUEST,
@@ -378,12 +414,16 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      
-      this.logger.error('Unexpected error in processDocumentText', error instanceof Error ? error : errorMessage, {
-        documentId,
-        operation: 'text_extraction',
-        errorType: 'PROCESSING_ERROR',
-      });
+
+      this.logger.error(
+        'Unexpected error in processDocumentText',
+        error instanceof Error ? error : errorMessage,
+        {
+          documentId,
+          operation: 'text_extraction',
+          errorType: 'PROCESSING_ERROR',
+        },
+      );
 
       throw new HttpException(
         {
@@ -435,11 +475,16 @@ export class DocumentsController {
       });
 
       if (result.status === 'success') {
-        this.logger.logChunkOperation('process', documentId, result.savedChunks.length, {
-          processingTimeMs: result.processingTimeMs,
-          statistics: result.chunkingResult.statistics,
-        });
-        
+        this.logger.logChunkOperation(
+          'process',
+          documentId,
+          result.savedChunks.length,
+          {
+            processingTimeMs: result.processingTimeMs,
+            statistics: result.chunkingResult.statistics,
+          },
+        );
+
         return {
           success: true,
           message: 'Chunks procesados exitosamente',
@@ -450,12 +495,16 @@ export class DocumentsController {
           },
         };
       } else {
-        this.logger.error('Chunk processing failed', JSON.stringify(result.errors), {
-          documentId,
-          operation: 'chunk_processing',
-          errors: result.errors,
-        });
-        
+        this.logger.error(
+          'Chunk processing failed',
+          JSON.stringify(result.errors),
+          {
+            documentId,
+            operation: 'chunk_processing',
+            errors: result.errors,
+          },
+        );
+
         return {
           success: false,
           message: 'Error procesando chunks',
@@ -472,12 +521,16 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      
-      this.logger.error('Unexpected error in processDocumentChunks', error instanceof Error ? error : errorMessage, {
-        documentId,
-        operation: 'chunk_processing',
-        errorType: 'CHUNK_PROCESSING_ERROR',
-      });
+
+      this.logger.error(
+        'Unexpected error in processDocumentChunks',
+        error instanceof Error ? error : errorMessage,
+        {
+          documentId,
+          operation: 'chunk_processing',
+          errorType: 'CHUNK_PROCESSING_ERROR',
+        },
+      );
 
       throw new HttpException(
         {
@@ -549,12 +602,16 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      
-      this.logger.error('Unexpected error in getDocumentChunks', error instanceof Error ? error : errorMessage, {
-        documentId,
-        operation: 'chunk_retrieval',
-        errorType: 'CHUNK_RETRIEVAL_ERROR',
-      });
+
+      this.logger.error(
+        'Unexpected error in getDocumentChunks',
+        error instanceof Error ? error : errorMessage,
+        {
+          documentId,
+          operation: 'chunk_retrieval',
+          errorType: 'CHUNK_RETRIEVAL_ERROR',
+        },
+      );
 
       throw new HttpException(
         {


### PR DESCRIPTION
### Implementations and Changes

This pull request increases the maximum allowed PDF upload size from 10MB to 100MB and updates both backend validation and middleware to support large file uploads. It also enhances the document upload endpoint to enforce PDF-only uploads at the interceptor level and improves logging consistency throughout the `DocumentsController`.

**File upload size and validation improvements:**

* Increased the maximum allowed upload size for PDF documents from 10MB to 100MB in both the use case validation (`UploadDocumentUseCase`) and the upload endpoint's file interceptor (`documents.controller.ts`). [[1]](diffhunk://#diff-d008bbb3784d656d2069eca205925f0acae10d4001f81e173b2f8353a04e07dfL35-R37) [[2]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL205-R246)
* Configured Express middleware in `main.ts` to accept large JSON and URL-encoded payloads up to 100MB, ensuring the backend can handle large file uploads.

**Document upload endpoint enhancements:**

* Updated the file upload interceptor in `documents.controller.ts` to use in-memory storage, enforce a 100MB file size limit, and restrict uploads to PDF files only, providing immediate feedback for invalid file types.

**Logging improvements:**

* Refactored all error and operation logging in `DocumentsController` to use a consistent, multi-line style and include structured context, improving readability and debugging. [[1]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL83-R90) [[2]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL188-R200) [[3]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL270-R306) [[4]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL321-R360) [[5]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL382-R426) [[6]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL438-R486) [[7]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL453-R506) [[8]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL476-R533) [[9]](diffhunk://#diff-1eb383cd6924034a49cec4cbb325e04509091e1fcdec431970b1e4694ccc672fL553-R614)

**Dependency update:**

* Added import of `memoryStorage` from `multer` for use in the file interceptor configuration.


> Examples of uploaded pdfs
![Imagen de WhatsApp 2025-09-06 a las 19 43 36_911d5e47](https://github.com/user-attachments/assets/d513064d-aec5-4c46-9885-6ddce6b3b0e3)
![Imagen de WhatsApp 2025-09-06 a las 19 44 45_c3f79bb0](https://github.com/user-attachments/assets/8cbce5a5-8acc-4ce0-8e34-2ae6b2386e28)
