### PR TITLE
Feat [MD-97]: Aumentar límite de carga de documentos PDF de 10MB a 100MB 

### DIFF
--- a/client/src/components/shared/UploadButton.tsx
+++ b/client/src/components/shared/UploadButton.tsx
@@ -152,8 +152,8 @@ interface UploadButtonProps {
  *   onUpload={processDocument}
  *   fileConfig={{
  *     accept: ".pdf,application/pdf",
- *     maxSize: 10 * 1024 * 1024,
- *     validationMessage: "Solo archivos PDF de máximo 10MB"
+ *     maxSize: 100 * 1024 * 1024,
+ *     validationMessage: "Solo archivos PDF de máximo 100MB"
  *   }}
  *   processingConfig={{
  *     steps: [

--- a/client/src/pages/documents/UploadDocumentPage.tsx
+++ b/client/src/pages/documents/UploadDocumentPage.tsx
@@ -46,8 +46,8 @@ const UploadDocumentPage: React.FC = () => {
 
   const fileConfig = {
     accept: ".pdf",
-    maxSize: 10 * 1024 * 1024, // 10MB
-    validationMessage: "Solo se permiten archivos PDF de hasta 10MB"
+    maxSize: 100 * 1024 * 1024, // 100MB
+    validationMessage: "Solo se permiten archivos PDF de hasta 100MB"
   };
 
   const processingConfig = {


### PR DESCRIPTION
# Resumen
Se aumenta el límite permitido para subir documentos PDF, pasando de **10MB** a **100MB**.  
Con este cambio, los usuarios pueden cargar documentos de hasta 100MB sin errores de validación y la interfaz muestra el nuevo límite actualizado.

# Qué se hizo
- Se actualizó la validación de tamaño máximo de archivo para permitir hasta 100MB.
- Se reemplazaron los mensajes de error que antes mostraban "10MB" → ahora indican "100MB".
- En la Card de subir PDF se modificó el texto mostrado para reflejar el nuevo límite.
- Se verificó que el flujo de subida se mantenga estable y consistente con el resto del sistema.

# Por qué
- Necesidad de soportar documentos PDF más pesados (reportes, manuales, documentos largos).
- Mejora la usabilidad al eliminar la restricción anterior de 10MB.
- Evita que los usuarios tengan que comprimir archivos grandes para poder subirlos.

# Cómo probar / QA
1. Navegar a la sección de carga de documentos.
2. Intentar subir un PDF **mayor a 100MB**:
   - Se debe mostrar un **error de validación** indicando que el archivo excede el límite de 100MB.
3. Intentar subir un PDF **menor a 100MB pero mayor a 10MB** (ejemplo: 50MB):
   - La carga debe completarse correctamente.
   - No debe mostrarse el error de 10MB anterior.
4. Revisar la **Card de subir PDF**:
   - El texto debe indicar claramente: `Límite: 100MB`.
5. Validar en navegadores principales (Chrome y Firefox).

# Archivos modificados
- [ ] Componente/Hook de validación de subida de archivos.
- [ ] Card de subir PDF (texto visible del límite).
- [ ] Mensajes de error en la UI.

# Capturas

![Pr1](https://github.com/user-attachments/assets/6614ef33-3f0e-4a02-8d15-62de2cbee622)
![Pr2](https://github.com/user-attachments/assets/92ccc5bc-df5c-4642-8513-2cc7ebaebf60)
![Pr3](https://github.com/user-attachments/assets/585560e3-3279-4333-959d-5aeceff1177f)