### PR TITLE
feat[US-075, US-076, # 121, # 125, # 132,# 134]!: Cambiar input de número de intentos, Escoger tiempo límite del examen, Reorganizar y unificar las 3 tablas de DB, Unificar controllers y normalizar rutas, Eliminar tabla savedExams y trasladar la logica de classId a tabla Exam, Foreign Keys reales para integridad

### DIFF
--- a/client/src/components/exams/ExamForm.css
+++ b/client/src/components/exams/ExamForm.css
@@ -1,3 +1,7 @@
+input[type="range"]:focus {
+  outline: none;
+  box-shadow: none;
+}
 .next-fixed {
   position: absolute;
   right: 32px;

--- a/client/src/components/exams/ExamForm.tsx
+++ b/client/src/components/exams/ExamForm.tsx
@@ -25,13 +25,24 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
     trueFalse: '',
     analysis: '',
     openEnded: '',
+    timeMinutes: 45,
   });
   
 
-  const totalQuestions = getTotalQuestions();
-
   const [step, setStep] = useState(0);
   const steps = ['Datos generales', 'Cantidad de preguntas', 'Tiempo y referencia'];
+
+  useEffect(() => {
+    if (step === 2) {
+      setValues((prev) => ({
+        ...prev,
+        timeMinutes: 45,
+      }));
+      setValue('timeMinutes', 45);
+    }
+  }, [step]);
+
+  const totalQuestions = getTotalQuestions();
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [sending, setSending] = useState(false);
@@ -48,7 +59,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
         trueFalse: '',
         analysis: '',
         openEnded: '',
-        timeMinutes: '',
+        timeMinutes: 45,
         reference: '',
       });
       setValue('subject', '');
@@ -108,6 +119,18 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
       setValue('subject', '');
       setValue('difficulty', '');
       setValue('attempts', '');
+      setTouched((prev) => ({
+        ...prev,
+        subject: false,
+        difficulty: false,
+        attempts: false,
+      }));
+      setErrors((prev) => ({
+        ...prev,
+        subject: '',
+        difficulty: '',
+        attempts: '',
+      }));
       onToast('Datos generales limpiados.', 'info');
     } else if (step === 1) {
       setValues((prev) => ({
@@ -125,10 +148,10 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
     } else if (step === 2) {
       setValues((prev) => ({
         ...prev,
-        timeMinutes: '',
+        timeMinutes: 45,
         reference: '',
       }));
-      setValue('timeMinutes', '');
+      setValue('timeMinutes', 45);
       setValue('reference', '');
       onToast('Tiempo y referencia limpiados.', 'info');
     }
@@ -213,7 +236,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
             <>
               <div className="form-group sm:col-span-2">
                 <label htmlFor="subject" className="block text-sm font-medium mb-1">
-                  Materia *
+                  Materia
                 </label>
                 <input
                   id="subject"
@@ -248,7 +271,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
 
               <div className="form-group">
                 <label htmlFor="difficulty" className="block text-sm font-medium mb-1">
-                  Dificultad *
+                  Dificultad
                 </label>
                 <select
                   id="difficulty"
@@ -291,7 +314,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
 
               <div className="form-group sm:col-span-1">
                 <label htmlFor="attempts" className="block text-sm font-medium mb-1">
-                  N.º de intentos *
+                  N.º de intentos
                 </label>
                 <input
                   id="attempts"
@@ -337,7 +360,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
               }}
             >
               <label className="w-full text-center font-bold text-[clamp(1rem,1.2vw+0.6rem,1.15rem)] my-0">
-                Cantidad de preguntas por tipo *
+                Cantidad de preguntas por tipo
               </label>
 
               <div
@@ -485,36 +508,25 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
 
           {step === 2 && (
             <>
-              <div className="form-group">
-                <label htmlFor="timeMinutes" className="block text-sm font-medium mb-1">
-                  Tiempo (min) *
-                </label>
-                <input
-                  id="timeMinutes"
-                  name="timeMinutes"
-                  type="number"
-                  min={45}
-                  max={240}
-                  step={1}
-                  placeholder="45"
-                  className="
-                    input-hover w-full rounded-lg border-2 px-3 py-2
-                    text-[clamp(0.95rem,0.7vw+0.75rem,1.05rem)]
-                    outline-none transition focus:ring-2
-                  "
-                  value={values.timeMinutes || ''}
-                  onChange={(e) => onChange('timeMinutes', e.target.value)}
-                  style={{
-                    background: token.colorBgContainer,
-                    color: token.colorText,
-                    borderColor: token.colorBorder,
-                    borderWidth: 2,
-                    borderStyle: 'solid',
-                  }}
-                />
-                {touched.timeMinutes && errors.timeMinutes && (
-                  <small className="error block mt-1 text-xs text-red-500">{errors.timeMinutes}</small>
-                )}
+              <div className="form-group" style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 8 }}>
+                <label htmlFor="timeMinutes" style={{ fontWeight: 500, marginBottom: 4 }}>Tiempo (min) </label>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 16, width: '100%' }}>
+                  <input
+                    id="timeMinutes"
+                    name="timeMinutes"
+                    type="range"
+                    min={45}
+                    max={240}
+                    step={1}
+                    value={values.timeMinutes}
+                    onChange={e => onChange('timeMinutes', e.target.value)}
+                    style={{
+                      flex: 1,
+                      accentColor: token.colorPrimary,
+                    }}
+                  />
+                  <span style={{ minWidth: 60, fontWeight: 500, fontSize: 16 }}>{values.timeMinutes} min</span>
+                </div>
               </div>
 
               <div className="form-group sm:col-span-2">
@@ -541,7 +553,7 @@ export const ExamForm = forwardRef<ExamFormHandle, Props>(function ExamForm(
                     borderStyle: 'solid',
                   }}
                 />
-                <small className="help block mt-1 text-xs opacity-70">Máx. 1000 caracteres</small>
+                <small className="help">Máx. 1000 caracteres</small>
                 {touched.reference && errors.reference && (
                   <small className="error block mt-1 text-xs text-red-500">{errors.reference}</small>
                 )}


### PR DESCRIPTION
# feat(examsDB)!: Reestructuración mayor de Exams y eliminación de SavedExam
Tareas:

125 -> https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/125

121 -> https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/121

132 -> https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/132 (cambio por 134, pero igual fue realizada)

134 -> https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/134

---

## Criterios de aceptación

- [x] La base de datos elimina `SavedExam` y `Exam.content`.
- [x] `Exam` ahora tiene un campo `classId` obligatorio (FK a `Classes`).
- [x] Índices creados para optimizar consultas.
- [x] Validaciones en español disponibles para la creación/edición de exámenes.
- [x] Endpoints actualizados:
  - `POST /api/exams`
  - `POST /api/exams/questions`
  - `GET /api/classes/:classId/exams`
- [x] Los repositorios Prisma validan propiedad mediante `exam.class.course.teacherId`.
- [x] `CreateExamDto` ahora requiere `classId`.
- [x] `GenerateQuestions` admite contexto `examId/classId`.
- [x] Eliminados tokens y providers relacionados con `SAVED_EXAM_REPO`.
- [x] Frontend ahora envía `classId` en la creación de exámenes y se reconfiguran los helpers.
- [x] Documentación actualizada con plan de migración y alias opcionales para endpoints.

---

## Archivos modificados

- `schema.prisma` (drop `SavedExam`, drop `Exam.content`, add `classId` + índice).
- `domain/` (eliminado `SavedExam`; puertos actualizados con `listByClassOwned`).
- `application/` (nuevos/actualizados commands y usecases).
- `infrastructure/prisma/` (repositorios con guards de propiedad).
- `http/controllers/exams.controller.ts` (nuevos endpoints REST).
- `dto/CreateExamDto.ts` (ahora requiere `classId`).
- `dto/GenerateQuestionsDto.ts` (contexto `examId/classId`).
- `client/services/exams.ts` (flujo adaptado con `classId`).
- `docs/migrations.md` (plan de migración y alias opcionales).

---

## Cambios realizados

### `schema.prisma`
- Se elimina el modelo `SavedExam`.
- `Exam` ahora contiene `classId` como FK hacia `Classes`.
- Eliminado campo `content` de `Exam`.
- Se agrega índice a `Exam.classId`.

### `domain`
- Eliminado el agregado/repositorio de `SavedExam`.
- Actualizados puertos (`listByClassOwned`).

### `application`
- Nuevos casos de uso para creación y listado por clase.
- Validaciones actualizadas en español.

### `infra/prisma`
- Repositorios incluyen guards de propiedad docente (`exam.class.course.teacherId`).

### `http`
- Nuevos endpoints:
  - `POST /api/exams`
  - `GET /api/classes/:classId/exams`

### `dto`
- `CreateExamDto` ahora requiere `classId`.
- `GenerateQuestionsDto` admite `examId/classId`.

### `tokens`
- Eliminados `SAVED_EXAM_REPO` y sus providers relacionados.

### `frontend`
- `service.exams` adaptado: requiere `classId` al crear exámenes.
- Legacy helpers reconfigurados para el nuevo flujo.


---

## Breaking Changes ⚠️

- **Base de datos modificada**  
  Ejecutar:  
  ```bash
  npx prisma migrate dev
  npx prisma generate
    ```
   En un caso extremo, borrar la base de datos con:

   ```bash
   npx prisma migrate reset
   ```

---

Tarea 84: https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/84
US 76:  https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/us/76

### Add
- Se agregó la siguiente regla CSS en `ExamForm.css` para eliminar el outline azul del slider al estar enfocado:

  ```css
  input[type="range"]:focus {
    outline: none;
    box-shadow: none;
  }
  ```

### Update
- El campo de tiempo pasó de ser un input box a un slider con rango 45–240 minutos.
- El slider de tiempo ahora utiliza el color primario del tema (`accentColor: token.colorPrimary`), igual al botón "Generar preguntas con IA".
- El valor inicial del slider siempre es 45 minutos al entrar al paso de “Tiempo y referencia”.
- Se eliminaron los mensajes de validación para el campo de tiempo.

### Delete
- No se eliminaron archivos ni líneas de código relevantes.

### Breaking Change
- No se realizaron cambios que rompan el flujo, la funcionalidad ni la compatibilidad del formulario.
---

Tarea 85: https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/85
US 76: https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/us/76

### Cuando se hace **POST /exams** con `timeMinutes` dentro del rango (45–240):
- [x] Se guarda el examen exitosamente (200/201).
- [x] La respuesta incluye `timeMinutes` **idéntico** al enviado.
- [x] **GET /exams/:id** devuelve el mismo `timeMinutes` guardado.

### Cuando se hace **POST /exams** con `timeMinutes` fuera del rango:
- [x] Se devuelve **400 Bad Request** con mensaje claro:
  - `< 45` → “Tiempo (minutos) mínimo: 45.”
  - `> 240` → “Tiempo (minutos) máximo: 240.”

### Compatibilidad:
- [x] No se cambian endpoints ni el shape del payload/respuesta.
- [x] No se rompe el frontend (el UI ya restringe 45–240).

---

### Archivos modificados
- `backend/src/modules/exams/infrastructure/http/dtos/create-exam.dto.ts`  
- `backend/src/modules/exams/domain/entities/exam.factory.ts`  

### Cambios realizados
- **`create-exam.dto.ts`**
  - Se añade validación con **class-validator**:
    - `@Min(45, { message: 'Tiempo (minutos) mínimo: 45.' })`
    - `@Max(240, { message: 'Tiempo (minutos) máximo: 240.' })`
  - Se mantiene `@IsInt()`; no se alteran otros campos.

- **`exam.factory.ts`**
  - Se refuerza el invariante de dominio:
    ```ts
    if (props.timeMinutes < 45 || props.timeMinutes > 240) {
      throw new DomainError('Tiempo (minutos) debe estar entre 45 y 240.');
    }
    ```
  - Se conservan las demás validaciones y la construcción del agregado.

---

### Postman

**URL base:** `{{baseUrl}}`  
> Ej.: `http://localhost:3000`

**Endpoints**
- Crear examen: **POST** `{{baseUrl}}/exams`

#### Requests configurados
1. **Create Exam (válido, mínimo 45) — POST `{{baseUrl}}/exams`**  
   **Orden exacto de claves (DTO):**  
   `subject`, `difficulty`, `reference`, `attempts`, `totalQuestions`, `timeMinutes`, `distribution`
   ```json
   {
     "subject": "Matemática I",
     "difficulty": "medio",
     "reference": "Parcial 1 2025",
     "attempts": 1,
     "totalQuestions": 10,
     "timeMinutes": 45,
     "distribution": {
       "multiple_choice": 6,
       "true_false": 2,
       "open_analysis": 1,
       "open_exercise": 1
     }
   }

Tarea 80: https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/task/80
US 75: https://tree.taiga.io/project/valeria_martinez-proyecto-de-ingenieria-de-software/us/75

# feat(exam-ui): #80 Reemplazar campo de intentos por selector visual compatible con temas

Como desarrollador frontend, quiero reemplazar el campo numérico de intentos por un selector visual con estilo consistente con el sistema de diseño (modo claro/oscuro) usando los tokens de Ant Design. Esto permite una mejor experiencia de usuario y mayor claridad visual en la creación de exámenes.

## Objetivo

- Reemplazar el campo actual por un selector visual para escoger el número de intentos (1, 2 o 3).
- Conservar la UX y funcionalidad actual del flujo de creación de examen.

## Alcance

- Selector visual de intentos con opciones `1`, `2`, `3`.
- Valor inicial por defecto: `1`.
- Valor seleccionado se envía correctamente al flujo de creación o guardado del examen.
- Compatible con tokens de tema claro/oscuro.
- Sin cambios en navegación ni estructura de pantalla.

---

## Criterios de aceptación

- [x] El docente puede visualizar y seleccionar entre `1`, `2` o `3` intentos.
- [x] El valor se persiste correctamente al guardar el examen.
- [x] Estilos visuales se adaptan al tema activo (light/dark).
- [x] Se conserva contraste accesible entre fondo y texto.
- [x] Se mantiene la navegación por teclado (input tipo radio oculto).
- [x] Adjuntada captura visual con los estilos aplicados.

---

## Estilos y tokens usados

- Fondo activo: `var(--app-colorPrimary)`
- Texto activo: `var(--app-colorTextOnPrimary)` (≈ blanco)
- Fondo inactivo: `var(--app-colorBgContainer)`
- Texto inactivo: `var(--app-colorText)`
- Borde contenedor: `var(--app-colorBorder)`
- Altura fija: `34px`, border-radius `6px`, disposición horizontal

---

## Archivos modificados

- `client/src/components/forms/ExamForm.tsx`
- `client/src/theme/ThemedVars.tsx` (uso de `colorTextLightSolid` como fallback para tokens sobre primarios)

---

## Captura de prueba

### Tema claro

<img width="1416" height="869" alt="imagen" src="https://github.com/user-attachments/assets/8508f6d1-c1f7-4b04-be4a-cf9cf3c8ad3d" />

<img width="1431" height="871" alt="imagen" src="https://github.com/user-attachments/assets/5393cf71-aa9b-477c-ab13-80137391da6a" />


### Tema oscuro

<img width="1440" height="890" alt="imagen" src="https://github.com/user-attachments/assets/e9ae71c6-d173-4832-aada-b0a7ad544cb6" />

<img width="1438" height="878" alt="imagen" src="https://github.com/user-attachments/assets/1ebaaf76-d10c-4841-81ef-3b64a220a086" />


---

## Consideraciones

- El sistema de tokens garantiza que los colores se ajustan automáticamente según el modo activo del usuario.
- El uso de variables CSS (`--app-color*`) permite una futura escalabilidad en temas personalizados o branding institucional.
- Puede reutilizarse la lógica y estilos para otros selectores similares (ej. dificultad).

---

⏱ **Tiempo estimado de implementación:** 1 día  
📌 **Estado:** completado y funcional