### PR TITLE
Feat(US-9): Creacion de la migracion exams-interview para las tablas de entrevista y examenes.

### DIFF
--- a/backend/prisma/migrations/20250913214821_exams_interview/migration.sql
+++ b/backend/prisma/migrations/20250913214821_exams_interview/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "public"."quiz_questions" (
+    "id" TEXT NOT NULL,
+    "classId" TEXT NOT NULL,
+    "signature" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "options" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "quiz_questions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."interview_questions" (
+    "id" TEXT NOT NULL,
+    "classId" TEXT NOT NULL,
+    "signature" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "interview_questions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "quiz_questions_signature_key" ON "public"."quiz_questions"("signature");
+
+-- CreateIndex
+CREATE INDEX "quiz_questions_classId_idx" ON "public"."quiz_questions"("classId");
+
+-- CreateIndex
+CREATE INDEX "quiz_questions_createdAt_idx" ON "public"."quiz_questions"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "quiz_questions_lastUsedAt_idx" ON "public"."quiz_questions"("lastUsedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "interview_questions_signature_key" ON "public"."interview_questions"("signature");
+
+-- CreateIndex
+CREATE INDEX "interview_questions_classId_idx" ON "public"."interview_questions"("classId");
+
+-- CreateIndex
+CREATE INDEX "interview_questions_createdAt_idx" ON "public"."interview_questions"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "interview_questions_lastUsedAt_idx" ON "public"."interview_questions"("lastUsedAt");
+
+-- AddForeignKey
+ALTER TABLE "public"."quiz_questions" ADD CONSTRAINT "quiz_questions_classId_fkey" FOREIGN KEY ("classId") REFERENCES "public"."Classes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."interview_questions" ADD CONSTRAINT "interview_questions_classId_fkey" FOREIGN KEY ("classId") REFERENCES "public"."Classes"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -415,6 +415,8 @@ model Classes {
 
   // relation 1:N
   enrollment    Enrollment[]
+  quizQuestions    QuizQuestion[]
+  interviewQuestions InterviewQuestion[]
 
   courseId      String            
   course        Course            @relation(fields: [courseId], references: [id])
@@ -436,3 +438,40 @@ model Enrollment {
 
   @@id([studentId, classId])
 }
+
+/* ===========================
+   Reinforcement (entrevistas y examenes )
+   =========================== */
+   model QuizQuestion {
+    id         String   @id @default(uuid())
+    classId    String
+    signature  String   @unique
+    text       String   @db.Text
+    type       String
+    options    Json?
+    createdAt  DateTime @default(now())
+    lastUsedAt DateTime?
+
+    // Relación con Classes
+    class      Classes  @relation(fields: [classId], references: [id], onDelete: Cascade)
+    @@index([classId])
+    @@index([createdAt])
+    @@index([lastUsedAt])
+    @@map("quiz_questions")
+  }
+
+  model InterviewQuestion {
+    id         String   @id @default(uuid())
+    classId    String
+    signature  String   @unique
+    text       String   @db.Text
+    createdAt  DateTime @default(now())
+    lastUsedAt DateTime?
+
+    // Relación con Classes
+    class      Classes  @relation(fields: [classId], references: [id], onDelete: Cascade)
+    @@index([classId])
+    @@index([createdAt])
+    @@index([lastUsedAt])
+    @@map("interview_questions")
+  }


### PR DESCRIPTION
# Descripción 
Se crearon las tablas para poder guardar las preguntas tanto para entrevistas como para examenes. 
## Add
Se añadio la migracion .sql para las tablas de entrevistas y examenes de reinforcement. 
## Update 
se modifico el archivo schema.prisma para la creacion de los model QuizQuestion{} y InterviewQuestion{}
``` 
/* ===========================
   Reinforcement (entrevistas y examenes )
   =========================== */
   model QuizQuestion {
    id         String   @id @default(uuid())
    classId    String
    signature  String   @unique
    text       String   @db.Text
    type       String
    options    Json?
    createdAt  DateTime @default(now())
    lastUsedAt DateTime?
    // Relación con Classes
    class      Classes  @relation(fields: [classId], references: [id], onDelete: Cascade)
    @@index([classId])
    @@index([createdAt])
    @@index([lastUsedAt])
    @@map("quiz_questions")
  }

  model InterviewQuestion {
    id         String   @id @default(uuid())
    classId    String
    signature  String   @unique
    text       String   @db.Text
    createdAt  DateTime @default(now())
    lastUsedAt DateTime?
    // Relación con Classes
    class      Classes  @relation(fields: [classId], references: [id], onDelete: Cascade)
    @@index([classId])
    @@index([createdAt])
    @@index([lastUsedAt])
    @@map("interview_questions")
  }
``` 
Se aplico la relación de 1 a muchos para poder guardar x preguntas para una clase.
## Delete 
No se eliminó codigo ni archivos para esta pull request. 
## Breaking Change 
No se produjo nada de lo que pueda afectar a codigo externo. 