### PR TITLE
US-9.4 Fix: ci.yml 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           working-directory: client
-          start: npm start:e2e
+          start: npm run start:e2e
           wait-on: http://localhost:5173
           wait-on-timeout: 120
           command: npm run cypress:run -- --spec cypress/e2e/login.cy.js


### PR DESCRIPTION
El comando anterior era inválido (npm start:e2e no existe), lo que causaba fallos en la ejecución de los tests E2E.
Con esta corrección, el workflow puede levantar correctamente la aplicación y ejecutar las pruebas de login en Cypress.

- Se asegura que el pipeline de CI pueda correr las pruebas E2E sin errores.

- No afecta otras partes del proyecto.