### PR TITLE
Fix/[MD-136]/softDeleteDocuments

### DIFF
--- a/backend/src/modules/repository_documents/application/commands/delete-document.usecase.ts
+++ b/backend/src/modules/repository_documents/application/commands/delete-document.usecase.ts
@@ -58,8 +58,11 @@ export class DeleteDocumentUseCase {
       await this.storageAdapter.softDeleteDocument(document.fileName);
       this.logger.log(`Soft delete en storage completado`);
 
-      this.logger.log(`Eliminando registro en base de datos...`);
-      await this.documentRepository.delete(documentId);
+      this.logger.log(`Estado DELETE en base de datos`);
+      await this.documentRepository.updateStatus(
+        documentId,
+        DocumentStatus.DELETED,
+      );
 
       this.logger.log(
         `Eliminación completada exitosamente: ${document.originalName}`,


### PR DESCRIPTION
## Problema

La funcionalidad de borrado lógico (soft delete) estaba rota debido a una inconsistencia entre las operaciones de base de datos y almacenamiento:

- **Almacenamiento**: Los archivos se movían correctamente a la carpeta `deleted/` en MinIO 
- **Base de datos**: Los documentos se **eliminaban permanentemente** (hard delete) de la base de datos 
- **Resultado**: No se podían detectar documentos eliminados para su restauración mediante hash

## Causa Raíz

En `DeleteDocumentUseCase.execute()`:
```typescript
// Antes: Eliminación permanente - pierde todos los metadatos
await this.documentRepository.delete(documentId);
```

Esto causaba que:
1. El archivo existiera en la carpeta `deleted/` de MinIO
2. No existiera registro en la base de datos con `status: 'DELETED'`
3. `CheckDeletedDocumentUseCase` no encontraba documentos para restaurar
4. Al subir el mismo documento, se trataba como nuevo en lugar de restaurar el existente

## Solución

Se modificó `DeleteDocumentUseCase` para realizar un borrado lógico en la base de datos:

```typescript
// Ahora: Borrado lógico - preserva metadatos para restauración
await this.documentRepository.updateStatus(documentId, DocumentStatus.DELETED);
```

## Cambios Realizados

### Archivos Modificados
- `backend/src/modules/repository_documents/application/commands/delete-document.usecase.ts`

### Cambios Principales
1. **Borrado Lógico en BD**: Los documentos ahora reciben `status: 'DELETED'` en lugar de ser eliminados
2. **Preservación de Metadatos**: Se mantienen fileHash, textHash y demás metadatos para la coincidencia por hash
3. **Habilitación de Restauración**: `CheckDeletedDocumentUseCase` ahora puede encontrar y restaurar documentos eliminados

## Pruebas Realizadas

### Antes de la Corrección
1. Subir documento → Éxito
2. Eliminar documento → Archivo movido a `deleted/`, registro eliminado de BD
3. Subir mismo documento → Se trataba como nueva subida (sin restauración)

### Después de la Corrección  
1. Subir documento → Éxito
2. Eliminar documento → Archivo movido a `deleted/`, registro marcado como `DELETED`
3. Subir mismo documento → **Detectado por hash y restaurado automáticamente** 


<img width="805" height="180" alt="image" src="https://github.com/user-attachments/assets/e140779c-694e-4196-ba74-140b7d995c4d" />
<img width="1573" height="739" alt="image" src="https://github.com/user-attachments/assets/5ee572df-98a1-465e-a35f-59ca9e911dc8" />
