### PR TITLE
Fix/[MD-137]/soft delete database

### DIFF
--- a/backend/prisma/migrations/20250916001753_add_status_to_document_chunks/migration.sql
+++ b/backend/prisma/migrations/20250916001753_add_status_to_document_chunks/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."document_chunks" ADD COLUMN     "status" TEXT NOT NULL DEFAULT 'ACTIVE';
+
+-- CreateIndex
+CREATE INDEX "document_chunks_status_idx" ON "public"."document_chunks"("status");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -190,6 +190,9 @@ model DocumentChunk {
   pageNumber      Int?                       // Página de origen (si aplica)
   type            String    @default("text") // Tipo de chunk (text, heading, list, etc.)
   
+  // Status para soft delete
+  status          String    @default("ACTIVE") // ACTIVE, DELETED
+  
   // Metadata estadística
   wordCount       Int       @default(0)      // Número de palabras
   charCount       Int       @default(0)      // Número de caracteres
@@ -206,6 +209,7 @@ model DocumentChunk {
   @@unique([documentId, chunkIndex])
   @@index([documentId])
   @@index([type])
+  @@index([status])
   @@index([wordCount])
   // Índice HNSW para búsqueda vectorial eficiente
   // CREATE INDEX CONCURRENTLY document_chunks_embedding_hnsw_idx ON "DocumentChunk" USING hnsw (embedding vector_cosine_ops);

--- a/backend/src/modules/repository_documents/application/use-cases/check-deleted-document.usecase.ts
+++ b/backend/src/modules/repository_documents/application/use-cases/check-deleted-document.usecase.ts
@@ -4,6 +4,7 @@ import type { DocumentRepositoryPort } from '../../domain/ports/document-reposit
 import type { DeletedDocumentRepositoryPort } from '../../domain/ports/deleted-document-repository.port';
 import type { TextExtractionPort } from '../../domain/ports/text-extraction.port';
 import type { DocumentStoragePort } from '../../domain/ports/document-storage.port';
+import type { DocumentChunkRepositoryPort } from '../../domain/ports/document-chunk-repository.port';
 import {
   CheckDeletedDocumentRequest,
   DeletedDocumentCheckResult,
@@ -19,6 +20,7 @@ export class CheckDeletedDocumentUseCase {
     private readonly deletedDocumentRepository: DeletedDocumentRepositoryPort,
     private readonly textExtraction: TextExtractionPort,
     private readonly documentStorage: DocumentStoragePort,
+    private readonly chunkRepository: DocumentChunkRepositoryPort,
   ) {}
 
   async execute(
@@ -145,6 +147,11 @@ export class CheckDeletedDocumentUseCase {
         await this.deletedDocumentRepository.restoreDocument(
           deletedDocument.id,
         );
+
+      // paso 4: restaurar chunks eliminados
+      this.logger.log(`restaurando chunks eliminados del documento: ${deletedDocument.id}`);
+      await this.chunkRepository.restoreByDocumentId(deletedDocument.id);
+      this.logger.log(`chunks restaurados exitosamente`);
 
       if (!restoredDocument) {
         this.logger.error(

--- a/backend/src/modules/repository_documents/documents.module.ts
+++ b/backend/src/modules/repository_documents/documents.module.ts
@@ -158,10 +158,19 @@ import { ContextualLoggerService } from './infrastructure/services/contextual-lo
       useFactory: (
         storageAdapter: S3StorageAdapter,
         documentRepository: PrismaDocumentRepositoryAdapter,
+        chunkRepository: PrismaDocumentChunkRepositoryAdapter,
       ) => {
-        return new DeleteDocumentUseCase(storageAdapter, documentRepository);
+        return new DeleteDocumentUseCase(
+          storageAdapter,
+          documentRepository,
+          chunkRepository,
+        );
       },
-      inject: [DOCUMENT_STORAGE_PORT, DOCUMENT_REPOSITORY_PORT],
+      inject: [
+        DOCUMENT_STORAGE_PORT,
+        DOCUMENT_REPOSITORY_PORT,
+        DOCUMENT_CHUNK_REPOSITORY_PORT,
+      ],
     },
     {
       provide: UploadDocumentUseCase,
@@ -273,12 +282,14 @@ import { ContextualLoggerService } from './infrastructure/services/contextual-lo
         deletedDocumentRepository: PrismaDeletedDocumentRepositoryAdapter,
         textExtraction: PdfTextExtractionAdapter,
         documentStorage: S3StorageAdapter,
+        chunkRepository: PrismaDocumentChunkRepositoryAdapter,
       ) => {
         return new CheckDeletedDocumentUseCase(
           documentRepository,
           deletedDocumentRepository,
           textExtraction,
           documentStorage,
+          chunkRepository,
         );
       },
       inject: [
@@ -286,6 +297,7 @@ import { ContextualLoggerService } from './infrastructure/services/contextual-lo
         DELETED_DOCUMENT_REPOSITORY_PORT,
         TEXT_EXTRACTION_PORT,
         DOCUMENT_STORAGE_PORT,
+        DOCUMENT_CHUNK_REPOSITORY_PORT,
       ],
     },
 

--- a/backend/src/modules/repository_documents/domain/ports/document-chunk-repository.port.ts
+++ b/backend/src/modules/repository_documents/domain/ports/document-chunk-repository.port.ts
@@ -67,6 +67,16 @@ export interface DocumentChunkRepositoryPort {
   deleteByDocumentId(documentId: string): Promise<void>;
 
   /**
+   * Marca todos los chunks de un documento como eliminados (soft delete)
+   */
+  softDeleteByDocumentId(documentId: string): Promise<void>;
+
+  /**
+   * Restaura todos los chunks eliminados de un documento
+   */
+  restoreByDocumentId(documentId: string): Promise<void>;
+
+  /**
    * Elimina un chunk específico
    */
   deleteById(id: string): Promise<void>;

--- a/backend/src/modules/repository_documents/infrastructure/persistence/prisma-document-chunk-repository.adapter.ts
+++ b/backend/src/modules/repository_documents/infrastructure/persistence/prisma-document-chunk-repository.adapter.ts
@@ -204,6 +204,62 @@ export class PrismaDocumentChunkRepositoryAdapter
   }
 
   /**
+   * Marca todos los chunks de un documento como eliminados (soft delete)
+   */
+  async softDeleteByDocumentId(documentId: string): Promise<void> {
+    try {
+      const result = await this.prisma.documentChunk.updateMany({
+        where: { 
+          documentId,
+          status: 'ACTIVE'
+        },
+        data: {
+          status: 'DELETED',
+          updatedAt: new Date(),
+        },
+      });
+
+      this.logger.log(
+        `Marcados como eliminados ${result.count} chunks del documento ${documentId}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Error marcando chunks como eliminados del documento ${documentId}:`,
+        error,
+      );
+      throw new Error(`Error en soft delete de chunks: ${error}`);
+    }
+  }
+
+  /**
+   * Restaura todos los chunks eliminados de un documento
+   */
+  async restoreByDocumentId(documentId: string): Promise<void> {
+    try {
+      const result = await this.prisma.documentChunk.updateMany({
+        where: { 
+          documentId,
+          status: 'DELETED'
+        },
+        data: {
+          status: 'ACTIVE',
+          updatedAt: new Date(),
+        },
+      });
+
+      this.logger.log(
+        `Restaurados ${result.count} chunks del documento ${documentId}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Error restaurando chunks del documento ${documentId}:`,
+        error,
+      );
+      throw new Error(`Error restaurando chunks: ${error}`);
+    }
+  }
+
+  /**
    * Elimina un chunk específico
    */
   async deleteById(id: string): Promise<void> {


### PR DESCRIPTION
## Descripción
Se ha implementado un sistema de eliminación soft delete para los chunks de documentos, lo que permite una mejor gestión del ciclo de vida de los datos y evita la pérdida de información durante la eliminación y restauración de documentos.

## Cambios Principales
- **Base de Datos**: 
  - Nuevo campo `status` en `DocumentChunk` con valores `ACTIVE`/`DELETED`
  - Índice para optimizar consultas por estado
- **Nuevos Métodos**:
  - `softDeleteByDocumentId()` - Marca chunks como eliminados
  - `restoreByDocumentId()` - Restaura chunks eliminados
- **Flujos Actualizados**:
  - Eliminación de documento: ahora usa soft delete
  - Restauración: reactiva los chunks automáticamente

## Pasos para Probar

### 1. Configuración Inicial
```bash
# tener la ultima version de la migracion
npx prisma migrate dev --name add_status_to_document_chunks
```

### 2. Probar Flujo Completo

#### Subir un Documento

Verifica que los chunks se creen con `status: 'ACTIVE'`:
```sql
SELECT id, "documentId", status 
FROM "DocumentChunk" 
WHERE "documentId" = 'id-del-documento';
```

#### Eliminar el Documento

Verifica que:
- El documento esté marcado como `DELETED`
- Sus chunks tengan `status: 'DELETED'`

#### Restaurar el Documento
Sube el mismo archivo nuevamente (debe activar el auto-restore).

Verifica que:
- El documento original sea restaurado
- Los chunks originales estén en `status: 'ACTIVE'`
- No se hayan creado chunks duplicados

### 3. Verificación Adicional
- Intenta buscar contenido en el documento restaurado
- Verifica que las búsquedas vectoriales funcionen correctamente
- Confirma que no hay duplicación de chunks en la base de datos


**Nota**: Los chunks ahora se marcan como eliminados en lugar de borrarse, lo que permite su restauración completa cuando se recupera un documento, incluyendo todos sus metadatos y relaciones.

### Pruebas
<img width="456" height="487" alt="image" src="https://github.com/user-attachments/assets/68a33e19-30f6-4c6d-be88-ade0bfed0fd7" />
