### PR TITLE
fix[MD-122]: Adjust pagination condition in DocumentDataSidebar component

### DIFF
--- a/client/src/components/documents/DocumentDataSidebar.tsx
+++ b/client/src/components/documents/DocumentDataSidebar.tsx
@@ -433,7 +433,7 @@ export const DocumentDataSidebar: React.FC<DocumentDataSidebarProps> = ({ docume
                         </Card>
                       ))}
 
-                      {filteredChunks.length > pageSize && (
+                      {filteredChunks.length > 0 && (
                         <Card size="small" style={{ textAlign: 'center' }}>
                           <Pagination current={currentPage} total={filteredChunks.length} pageSize={pageSize} onChange={setCurrentPage} onShowSizeChange={(_, size) => { setPageSize(size); setCurrentPage(1); }} showSizeChanger={!isMobile} showQuickJumper={!isMobile} showTotal={!isMobile ? (total, range) => `${range[0]}-${range[1]} de ${total} chunks` : undefined} pageSizeOptions={['5','10','20','50']} size={isMobile ? "small" : "default"} simple={!screens.sm} />
                         </Card>


### PR DESCRIPTION
This pull request makes a small update to the pagination logic in the `DocumentDataSidebar` component. Now, the pagination controls will be displayed whenever there is at least one chunk, rather than only when there are more chunks than the page size.

**Before:**
<img width="1019" height="337" alt="image" src="https://github.com/user-attachments/assets/1c5dfe37-b1de-49ab-93d9-41f55bac7253" />
<img width="1033" height="518" alt="image" src="https://github.com/user-attachments/assets/0892b201-062a-4735-b172-6075f41ee38f" />

**After:**
<img width="943" height="865" alt="image" src="https://github.com/user-attachments/assets/48e66ae1-21d2-42c2-9843-9a2afe2dee01" />
