### PR TITLE
Fix[MD-124]: Correct translate endpoints

### DIFF
--- a/backend/src/modules/repository_documents/application/queries/get-documents-by-subject.usecase.ts
+++ b/backend/src/modules/repository_documents/application/queries/get-documents-by-subject.usecase.ts
@@ -4,7 +4,7 @@ import type { DocumentStoragePort } from '../../domain/ports/document-storage.po
 import { ContractDocumentListItem } from '../../domain/entities/contract-document-list-item';
 
 export interface GetDocumentsBySubjectRequest {
-  materiaId: string;
+  subjectId: string;
   tipo?: string;
   page?: number;
   limit?: number;
@@ -26,7 +26,7 @@ export class GetDocumentsBySubjectUseCase {
   async execute(
     request: GetDocumentsBySubjectRequest,
   ): Promise<GetDocumentsBySubjectResponse> {
-    const { materiaId, tipo, page = 1, limit = 10 } = request;
+    const { subjectId, tipo, page = 1, limit = 10 } = request;
 
     // Calcular offset para paginación
     const offset = (page - 1) * limit;
@@ -34,7 +34,7 @@ export class GetDocumentsBySubjectUseCase {
     try {
       // Obtener documentos de la base de datos filtrados por curso
       const dbDocuments = await this.documentRepository.findByCourseId(
-        materiaId,
+        subjectId,
         offset,
         limit,
         tipo,
@@ -42,7 +42,7 @@ export class GetDocumentsBySubjectUseCase {
 
       // Obtener el total de documentos para la materia
       const total = await this.documentRepository.countByCourseId(
-        materiaId,
+        subjectId,
         tipo,
       );
 
@@ -92,7 +92,7 @@ export class GetDocumentsBySubjectUseCase {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
       throw new Error(
-        `Error al obtener documentos de la materia ${materiaId}: ${errorMessage}`,
+        `Error al obtener documentos de la materia ${subjectId}: ${errorMessage}`,
       );
     }
   }

--- a/backend/src/modules/repository_documents/infrastructure/http/contract-documents.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/contract-documents.controller.ts
@@ -23,7 +23,7 @@ import {
  * Controlador para endpoints del contrato con el módulo de estudiantes
  * Base URL: /api/v1/documentos
  */
-@Controller('api/v1/documentos')
+@Controller('api/v1/documents')
 @UseGuards(AuthGuard('jwt'))
 export class ContractDocumentsController {
   constructor(
@@ -32,22 +32,18 @@ export class ContractDocumentsController {
     private readonly logger: ContextualLoggerService,
   ) {}
 
-  /**
-   * GET /materias/{materiaId}/documentos
-   * Obtiene la lista de documentos disponibles para una materia.
-   */
-  @Get('materias/:materiaId/documentos')
+  @Get('subject/:subjectId/documents')
   async getDocumentsBySubject(
-    @Param('materiaId') materiaId: string,
+    @Param('subjectId') subjectId: string,
     @Query() query: GetDocumentsBySubjectQueryDto,
   ): Promise<ContractDocumentListResponseDto> {
     try {
       this.logger.logDocumentOperation('list', undefined, {
-        materiaId,
+        subjectId,
         query,
       });
 
-      if (!materiaId || !materiaId.trim()) {
+      if (!subjectId || !subjectId.trim()) {
         throw new HttpException(
           {
             statusCode: HttpStatus.BAD_REQUEST,
@@ -59,7 +55,7 @@ export class ContractDocumentsController {
       }
 
       const result = await this.getDocumentsBySubjectUseCase.execute({
-        materiaId: materiaId.trim(),
+        subjectId: subjectId.trim(),
         tipo: query.tipo,
         page: query.page || 1,
         limit: query.limit || 10,
@@ -79,7 +75,7 @@ export class ContractDocumentsController {
       );
 
       this.logger.log('Documents retrieved successfully for subject', {
-        materiaId,
+        subjectId,
         totalDocuments: result.total,
         documentsReturned: documentos.length,
         page: result.page,
@@ -98,7 +94,7 @@ export class ContractDocumentsController {
         'Error retrieving documents by subject',
         error instanceof Error ? error : errorMessage,
         {
-          materiaId,
+          subjectId,
           errorType: 'DOCUMENTS_BY_SUBJECT_ERROR',
         },
       );
@@ -145,7 +141,7 @@ export class ContractDocumentsController {
    * GET /documentos/{docId}/contenido
    * Obtiene el contenido extraído de un documento específico.
    */
-  @Get(':docId/contenido')
+  @Get(':docId/content')
   async getDocumentContent(
     @Param('docId') docId: string,
   ): Promise<DocumentContentResponseDto> {

--- a/infra/docker/minio.compose.yml
+++ b/infra/docker/minio.compose.yml
@@ -40,3 +40,13 @@ services:
       echo 'Bucket created and configured successfully!';
       "
     restart: "no"
+    networks:
+      - minio-network
+
+volumes:
+  minio-data:
+
+networks:
+  minio-network:
+    driver: bridge
+    name: learning-agent-network

--- a/infra/docker/minio.compose.yml
+++ b/infra/docker/minio.compose.yml
@@ -40,13 +40,3 @@ services:
       echo 'Bucket created and configured successfully!';
       "
     restart: "no"
-    networks:
-      - minio-network
-
-volumes:
-  minio-data:
-
-networks:
-  minio-network:
-    driver: bridge
-    name: learning-agent-network


### PR DESCRIPTION
This pull request refactors the naming conventions and API endpoints related to subjects and documents in the repository documents module, aiming for more consistent terminology and RESTful routes. Additionally, it updates the MinIO Docker Compose configuration to use a dedicated network.

**API and Naming Refactor:**

* Renamed all references from `materiaId` to `subjectId` in the `GetDocumentsBySubjectUseCase` logic, request interface, and error handling, ensuring consistent terminology for subject identification. [[1]](diffhunk://#diff-bd2479f840c022a07c2b575b936261e9ea612456d48a7d75b212ffa3cb552577L7-R7) [[2]](diffhunk://#diff-bd2479f840c022a07c2b575b936261e9ea612456d48a7d75b212ffa3cb552577L29-R45) [[3]](diffhunk://#diff-bd2479f840c022a07c2b575b936261e9ea612456d48a7d75b212ffa3cb552577L95-R95)
* Updated controller endpoints to use more RESTful and English-based routes: changed base URL from `/api/v1/documentos` to `/api/v1/documents`, and the document listing endpoint from `/materias/{materiaId}/documentos` to `/subject/{subjectId}/documents`. Also updated parameter names and logging accordingly. [[1]](diffhunk://#diff-f2c684f9f89886fb83837eada7c304e988638364141e69c5dd63d164a84200bbL26-R26) [[2]](diffhunk://#diff-f2c684f9f89886fb83837eada7c304e988638364141e69c5dd63d164a84200bbL35-R46) [[3]](diffhunk://#diff-f2c684f9f89886fb83837eada7c304e988638364141e69c5dd63d164a84200bbL62-R58) [[4]](diffhunk://#diff-f2c684f9f89886fb83837eada7c304e988638364141e69c5dd63d164a84200bbL82-R78) [[5]](diffhunk://#diff-f2c684f9f89886fb83837eada7c304e988638364141e69c5dd63d164a84200bbL101-R97)
* Changed the endpoint for retrieving document content from `/documentos/{docId}/contenido` to `/documents/{docId}/content` for consistency with the new naming scheme.

**Infrastructure Updates:**

* Added a dedicated Docker network (`learning-agent-network`) to the MinIO Docker Compose configuration, improving container isolation and network management.