### PR TITLE
fix[MD-141]: Increase timeout durations for file uploads and API requests

### DIFF
--- a/client/src/api/apiClient.ts
+++ b/client/src/api/apiClient.ts
@@ -9,11 +9,29 @@ const apiClient = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
+  timeout: 60000, // 1 minuto para peticiones generales
+});
+
+// Cliente específico para uploads con timeout extendido
+export const uploadApiClient = axios.create({
+  baseURL: API_URL || "http://localhost:3000/",
+  timeout: 600000, // 10 minutos para uploads
 });
 
 apiClient.interceptors.request.use((config) => {
   const token = readAuth().accessToken;
   if (token && !config.url?.includes("auth/login")) {
+    if (config.headers) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+  return config;
+})
+
+// Aplicar interceptors al cliente de upload también
+uploadApiClient.interceptors.request.use((config) => {
+  const token = readAuth().accessToken;
+  if (token) {
     if (config.headers) {
       config.headers['Authorization'] = `Bearer ${token}`;
     }

--- a/client/src/components/shared/ChunkedUploadButton.tsx
+++ b/client/src/components/shared/ChunkedUploadButton.tsx
@@ -317,6 +317,16 @@ const ChunkedUploadButton: React.FC<ChunkedUploadButtonProps> = ({
       lastProgressUpdate.current = Date.now();
       speedHistory.current = [];
 
+      // Mostrar advertencia para archivos grandes
+      const fileSizeMB = file.size / (1024 * 1024);
+      if (fileSizeMB > 50) {
+        message.warning({
+          content: `Archivo grande detectado (${fileSizeMB.toFixed(1)} MB). El procesamiento puede tardar varios minutos. Por favor, no cierres esta ventana.`,
+          duration: 8,
+          style: { marginTop: '10vh' }
+        });
+      }
+
       const options: ChunkedUploadOptions = {
         chunkSize: fileConfig.chunkSize || 2 * 1024 * 1024,
         maxRetries: 3,
@@ -568,6 +578,20 @@ const ChunkedUploadButton: React.FC<ChunkedUploadButtonProps> = ({
             showIcon
             style={{ 
               marginTop: '16px',
+              fontSize: isSmallScreen ? '12px' : '14px'
+            }}
+          />
+        )}
+        
+        {/* Mensaje informativo específico para archivos grandes en procesamiento */}
+        {currentPhase === 'processing' && selectedFile && (selectedFile.size / (1024 * 1024)) > 50 && (
+          <Alert
+            message="Procesando archivo grande"
+            description={`Este archivo de ${((selectedFile.size) / (1024 * 1024)).toFixed(1)} MB está siendo procesado. El tiempo estimado puede ser de 5-10 minutos dependiendo del tamaño. Por favor, mantén esta ventana abierta.`}
+            type="warning"
+            showIcon
+            style={{ 
+              marginTop: '12px',
               fontSize: isSmallScreen ? '12px' : '14px'
             }}
           />

--- a/client/src/services/api/jsonInstance.ts
+++ b/client/src/services/api/jsonInstance.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000',
   withCredentials: true,
-  timeout: 15000,
+  timeout: 60000, // 1 minuto para peticiones generales
 });
 
 export default api;

--- a/client/src/services/chunkedUpload.service.ts
+++ b/client/src/services/chunkedUpload.service.ts
@@ -117,7 +117,8 @@ class ChunkedUploadService {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
-          cancelToken: cancelTokenSource.token
+          cancelToken: cancelTokenSource.token,
+          timeout: 600000 // 10 minutos para inicialización de uploads
         }
       );
 

--- a/client/src/services/documents.service.ts
+++ b/client/src/services/documents.service.ts
@@ -186,7 +186,7 @@ export const documentService = {
         formData,
         { 
           headers,
-          timeout: 30000 // 30 segundos de timeout
+          timeout: 600000 // 10 minutos de timeout para uploads de archivos grandes
         }
       );
 


### PR DESCRIPTION
This pull request introduces improvements for handling large file uploads in the client application. The changes focus on increasing timeout limits for upload-related requests, providing user feedback during large file processing, and ensuring authentication headers are correctly set for upload requests.

**Timeout and API client improvements:**

* Added a dedicated `uploadApiClient` in `client/src/api/apiClient.ts` with a 10-minute timeout for file uploads, while general requests use a 1-minute timeout.
* Applied authentication interceptors to `uploadApiClient` to ensure upload requests include the access token.
* Increased timeout for general API requests in `client/src/services/api/jsonInstance.ts` to 1 minute.
* Set a 10-minute timeout for upload initialization requests in `client/src/services/chunkedUpload.service.ts` and for large file uploads in `client/src/services/documents.service.ts`. [[1]](diffhunk://#diff-5961442352854262029362ea272b0b5d6c2229dd4ae2b0a32e4573c9f9cf2841L120-R121) [[2]](diffhunk://#diff-665f0b6a327269a4767a47e38815d9db8c4d93f423268e9c12f135143ab4a996L189-R189)

**User feedback for large uploads:**

* Added a warning message in `client/src/components/shared/ChunkedUploadButton.tsx` when a user selects a file larger than 50MB, informing them about potential processing delays.
* Displayed a processing alert for large files during the upload phase, with estimated time and instructions to keep the window open.

