### PR TITLE
fix: Ajustar tooltip embeddings evitando el desbordamiento

### DIFF
--- a/client/src/components/documents/DocumentDataSidebar.tsx
+++ b/client/src/components/documents/DocumentDataSidebar.tsx
@@ -208,7 +208,15 @@ export const DocumentDataSidebar: React.FC<DocumentDataSidebarProps> = ({ docume
           </Button>
         </Tooltip>
 
-        <Tooltip title="Generar embeddings para búsqueda semántica">
+        <Tooltip 
+          title="Generar embeddings para búsqueda semántica"
+          placement={isMobile ? "topRight" : "top"}
+          getPopupContainer={(trigger) => trigger?.parentElement || window.document.body}
+          overlayStyle={{ 
+            maxWidth: isMobile ? '200px' : '300px',
+            fontSize: isMobile ? '12px' : '14px'
+          }}
+        >
           <Button
             type="primary"
             icon={<SyncOutlined spin={isLoading} />}


### PR DESCRIPTION
# Resumen
Se corrige el problema de desbordamiento del tooltip del botón **"Generar embeddings"** en la pestaña Chunks del sidebar de documentos.  
Con este cambio, el tooltip permanece visible y legible en dispositivos móviles, mejorando la experiencia del usuario.

# Qué se hizo
- Ajuste en `DocumentDataSidebar.tsx`:
  - Se implementó posicionamiento responsivo del tooltip (`topRight` para móviles, `top` para desktop).
  - Se configuró un contenedor personalizado con `getPopupContainer` para mejor control de posicionamiento.
  - Se añadieron estilos adaptativos con `overlayStyle` para optimizar el ancho y tamaño de fuente en móviles.
- Se mantuvieron todos los estilos y comportamientos existentes para dispositivos desktop.
- Se probaron los cambios en diferentes tamaños de pantalla.

# Por qué
- El tooltip se desbordaba fuera de los límites de la pantalla en dispositivos móviles, haciendo que el texto fuera ilegible o invisible.
- Esta situación afectaba la usabilidad y accesibilidad del componente en pantallas pequeñas.
- El ajuste mejora la experiencia del usuario manteniendo la funcionalidad completa del tooltip.

# Cómo probar / QA
1. Iniciar la app en entorno local.
2. Navegar al sidebar de documentos y abrir la pestaña **"Chunks"**.
3. Verificar en dispositivos móviles o usando herramientas de desarrollador:
   - Hacer hover sobre el botón **"Embeddings"**.
   - El tooltip debe aparecer en posición `topRight` y permanecer completamente visible.
   - El texto debe ser legible con el tamaño de fuente reducido (12px).
4. Verificar en dispositivos desktop:
   - El tooltip debe mantener la posición `top` original.
   - El tamaño de fuente debe ser 14px.
   - No debe haber cambios en el comportamiento existente.
5. Probar en diferentes navegadores (Chrome, Firefox, Safari) y orientaciones (portrait/landscape).

# Archivos modificados
- `client/src/components/documents/DocumentDataSidebar.tsx` — ajustes de posicionamiento y estilos del tooltip del botón "Embeddings".

# Captura
<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/616517bb-dcb9-41e4-9cda-4a6c1a7fd63e" />
<img width="1257" height="726" alt="image" src="https://github.com/user-attachments/assets/f69d0d26-2214-446a-afd7-c3b4f0b4258e" />

