### PR TITLE
fix(prisma): remove duplicate quizQuestions field from Course model

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -554,8 +554,6 @@ model Course {
   quizQuestions    QuizQuestion[]
   interviewQuestions  InterviewQuestion[]
 
-  quizQuestions QuizQuestion[]
-
   createdAt     DateTime          @default(now())
   updatedAt     DateTime          @updatedAt
 }


### PR DESCRIPTION
# Cambios realizados

- Se elimina un campo duplicado `quizQuestions` del modelo `Course` en el esquema de **Prisma**.


