### PR TITLE
feat: introduce auth domain exceptions and update login use case

### DIFF
--- a/backend/src/modules/identity/domain/exceptions/auth.exceptions.ts
+++ b/backend/src/modules/identity/domain/exceptions/auth.exceptions.ts
@@ -1,0 +1,17 @@
+export class InvalidCredentialsError extends Error {
+  public readonly code = 'AUTH_INVALID_CREDENTIALS';
+
+  constructor() {
+    super('Invalid credentials provided.');
+    this.name = 'InvalidCredentialsError';
+  }
+}
+
+export class InactiveUserError extends Error {
+  public readonly code = 'AUTH_INACTIVE_USER';
+
+  constructor() {
+    super('User account is inactive.');
+    this.name = 'InactiveUserError';
+  }
+}


### PR DESCRIPTION
Se implementaron excepciones específicas para el dominio de autenticación (InvalidCredentialsError e InactiveUserError) y se reemplazaron los throw new Error() genéricos en el caso de uso de login.