### PR TITLE
Fix: #41 Move domain logic

### DIFF
--- a/backend/src/modules/exams-chat/exams-chat.module.ts
+++ b/backend/src/modules/exams-chat/exams-chat.module.ts
@@ -15,26 +15,9 @@ import { InterviewExamDbModule } from '../interview-exam-db/interview-exam-db.mo
 import { DocumentsModule } from '../repository_documents/documents.module';
 import { LlmModule } from '../llm/llm.module';
 
-// Bloque de AiGenModule comentado: no está definido ni importado.
-// const AiGeneratorClass =
-//   (AiGenModule as any).AIQuestionGenerator ??
-//   (AiGenModule as any).AiQuestionGenerator ??
-//   (AiGenModule as any).default;
-
-// class AiGeneratorFallback {
-//   async generateOptions(_text: string): Promise<string[]> {
-//     throw new Error('AI generator not available');
-//   }
-// }
-
-// const AiProvider =
-//   typeof AiGeneratorClass === 'function'
-//     ? { provide: EXAM_AI_GENERATOR, useClass: AiGeneratorClass }
-//     : { provide: EXAM_AI_GENERATOR, useClass: AiGeneratorFallback };
-
 @Module({
   imports: [
-    InterviewModule,
+    InterviewModule, // ← Ya exporta DsIntService, NO agregar en providers
     PromptTemplateModule,
     InterviewExamDbModule,
     DocumentsModule,
@@ -42,6 +25,7 @@ import { LlmModule } from '../llm/llm.module';
   ],
   controllers: [ExamsChatController],
   providers: [
+    // REMOVER: DsIntService de aquí - ya viene de InterviewModule
     { provide: EXAM_AI_GENERATOR, useClass: AIQuestionGenerator },
     { provide: EXAM_QUESTION_REPO, useClass: PrismaQuestionRepositoryAdapter },
     { provide: 'AUDIT_REPO', useClass: PrismaAuditRepositoryAdapter },
@@ -55,4 +39,4 @@ import { LlmModule } from '../llm/llm.module';
     PublishGeneratedQuestionUseCase,
   ],
 })
-export class ExamsChatModule { }
+export class ExamsChatModule {}

--- a/backend/src/modules/exams-chat/infrastructure/ai/ai-question.generator.ts
+++ b/backend/src/modules/exams-chat/infrastructure/ai/ai-question.generator.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import type { LlmPort } from '../../../llm/domain/ports/llm.port';
 import { LLM_PORT } from '../../../llm/tokens';
-import { DsIntService } from 'src/modules/interviewChat/infrastructure/dsInt.service';
+import { DsIntService } from '../../../interviewChat/infrastructure/dsInt.service';
 
 export type GeneratedOptions = {
   options: string[];
@@ -18,8 +18,8 @@ export class AIQuestionGenerator {
   private readonly logger = new Logger(AIQuestionGenerator.name);
 
   constructor(
-    @Inject(LLM_PORT) private readonly deepseek?: LlmPort,
-    private readonly dsIntService?: DsIntService, 
+    @Inject(LLM_PORT) private readonly deepseek: LlmPort,
+    private readonly dsIntService: DsIntService,
   ) {}
 
   private normalizeLine(l: string) {
@@ -27,12 +27,8 @@ export class AIQuestionGenerator {
   }
 
   async generateQuestion(): Promise<GeneratedQuestion> {
-    if (!this.dsIntService)
-      return {
-        text: 'Genera una pregunta sobre algoritmos de programación, de opción múltiple',
-      };
     const resp = await this.dsIntService.generateQuestion(
-      'Genera una pregunta sobre algoritmos de programación, de opción múltiple',
+      '1',
       '1',
     );
     const text =
@@ -42,12 +38,8 @@ export class AIQuestionGenerator {
   }
 
   async generateTrueFalseQuestion(): Promise<GeneratedQuestion> {
-    if (!this.dsIntService)
-      return {
-        text: 'El algoritmo de Quicksort siempre es estable. (Verdadero o Falso)',
-      };
     const resp = await this.dsIntService.generateQuestion(
-      'Genera una pregunta de verdadero o falso sobre algoritmos de programación',
+      '1',
       '1',
     );
     const text =
@@ -57,72 +49,72 @@ export class AIQuestionGenerator {
   }
 
   async generateOptions(questionText: string): Promise<GeneratedOptions> {
-  if (!questionText?.trim()) throw new Error('Text required');
-  const fallback: GeneratedOptions = {
-    options: [
-      `${questionText} — opción A`,
-      `${questionText} — opción B`,
-      `${questionText} — opción C`,
-      `${questionText} — opción D`,
-    ],
-    correctIndex: null,
-    confidence: null,
-  };
-  
-  if (!this.deepseek) return fallback;
-  
-  const maxAttempts = 3;
-  for (let i = 0; i < maxAttempts; i++) {
-    try {
-      const resp = await this.deepseek.complete(
-        `Genera 4 opciones distintas para esta pregunta: "${questionText}"`,
-        { model: { provider: 'deepseek', name: 'deepseek-chat' } },
-      );
-      const candidate = (resp?.text ?? '').toString().trim();
-      if (!candidate) continue;
-      
-      const parsed = this.parseCandidate(candidate);
-      if (parsed && parsed.length >= 4) {
-        return {
-          options: parsed.slice(0, 4),
-          correctIndex: null,
-          confidence: null,
-        };
-      }
-
-      const lines = candidate
-        .split(/\r?\n/)
-        .map((l) => l.trim())
-        .filter(Boolean)
-        .map(this.normalizeLine);
-
-      if (lines.length >= 4) {
-        return {
-          options: lines.slice(0, 4),
-          correctIndex: null,
-          confidence: null,
-        };
-      }
-
-      const pieces = candidate
-        .split(/;|\/|\||\t/)
-        .map((p) => p.trim())
-        .filter(Boolean);
+    if (!questionText?.trim()) throw new Error('Text required');
+    const fallback: GeneratedOptions = {
+      options: [
+        `${questionText} — opción A`,
+        `${questionText} — opción B`,
+        `${questionText} — opción C`,
+        `${questionText} — opción D`,
+      ],
+      correctIndex: null,
+      confidence: null,
+    };
+    
+    if (!this.deepseek) return fallback;
+    
+    const maxAttempts = 3;
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        const resp = await this.deepseek.complete(
+          `Genera 4 opciones distintas para esta pregunta: "${questionText}"`,
+          { model: { provider: 'deepseek', name: 'deepseek-chat' } },
+        );
+        const candidate = (resp?.text ?? '').toString().trim();
+        if (!candidate) continue;
         
-      if (pieces.length >= 4) {
-        return {
-          options: pieces.slice(0, 4),
-          correctIndex: null,
-          confidence: null,
-        };
+        const parsed = this.parseCandidate(candidate);
+        if (parsed && parsed.length >= 4) {
+          return {
+            options: parsed.slice(0, 4),
+            correctIndex: null,
+            confidence: null,
+          };
+        }
+
+        const lines = candidate
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .filter(Boolean)
+          .map(this.normalizeLine);
+
+        if (lines.length >= 4) {
+          return {
+            options: lines.slice(0, 4),
+            correctIndex: null,
+            confidence: null,
+          };
+        }
+
+        const pieces = candidate
+          .split(/;|\/|\||\t/)
+          .map((p) => p.trim())
+          .filter(Boolean);
+          
+        if (pieces.length >= 4) {
+          return {
+            options: pieces.slice(0, 4),
+            correctIndex: null,
+            confidence: null,
+          };
+        }
+      } catch (_) {
+        continue;
       }
-    } catch (_) {
-      continue;
     }
+    
+    return fallback;
   }
-  
-  return fallback;
-}
 
   private parseCandidate(candidate: string): string[] {
     if (!candidate) return [];

--- a/backend/src/modules/exams-chat/infrastructure/ai/ai-question.generator.ts
+++ b/backend/src/modules/exams-chat/infrastructure/ai/ai-question.generator.ts
@@ -123,24 +123,6 @@ export class AIQuestionGenerator {
   
   return fallback;
 }
-  private parseCandidate(candidate: string): string[] {
-    if (!candidate) return [];
-
-    const lines = candidate
-      .split(/\r?\n/)
-      .map((l) => this.normalizeLine(l))
-      .filter(Boolean);
-    if (lines.length >= 4) return lines;
-
-    const pieces = candidate
-      .split(/;|\/|\||\t/)
-      .map((p) => p.trim())
-      .filter(Boolean);
-    if (pieces.length >= 4) return pieces;
-
-    this.logger.warn(`parseCandidate no pudo procesar: "${candidate}"`);
-    return [];
-  }
 
   private parseCandidate(candidate: string): string[] {
     if (!candidate) return [];

--- a/backend/src/modules/identity/domain/services/token-expiration.service.spec.ts
+++ b/backend/src/modules/identity/domain/services/token-expiration.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { 
+  TokenExpirationService, 
+  InvalidTTLFormatError, 
+  UnsupportedTTLUnitError 
+} from './token-expiration.service';
+
+describe('TokenExpirationService', () => {
+  let service: TokenExpirationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TokenExpirationService],
+    }).compile();
+
+    service = module.get<TokenExpirationService>(TokenExpirationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('calculateExpiration', () => {
+    it('should calculate expiration for seconds', () => {
+      const baseDate = new Date('2024-01-01T00:00:00Z');
+      const result = service.calculateExpiration('30s', baseDate);
+      
+      expect(result.expiresAt).toEqual(new Date('2024-01-01T00:00:30Z'));
+      expect(result.milliseconds).toBe(30000);
+    });
+
+    it('should calculate expiration for minutes', () => {
+      const baseDate = new Date('2024-01-01T00:00:00Z');
+      const result = service.calculateExpiration('15m', baseDate);
+      
+      expect(result.expiresAt).toEqual(new Date('2024-01-01T00:15:00Z'));
+      expect(result.milliseconds).toBe(900000);
+    });
+
+    it('should calculate expiration for hours', () => {
+      const baseDate = new Date('2024-01-01T00:00:00Z');
+      const result = service.calculateExpiration('2h', baseDate);
+      
+      expect(result.expiresAt).toEqual(new Date('2024-01-01T02:00:00Z'));
+      expect(result.milliseconds).toBe(7200000);
+    });
+
+    it('should calculate expiration for days', () => {
+      const baseDate = new Date('2024-01-01T00:00:00Z');
+      const result = service.calculateExpiration('7d', baseDate);
+      
+      expect(result.expiresAt).toEqual(new Date('2024-01-08T00:00:00Z'));
+      expect(result.milliseconds).toBe(604800000);
+    });
+
+    it('should use current date when no base date provided', () => {
+      const before = new Date();
+      const result = service.calculateExpiration('1h');
+      const after = new Date(before.getTime() + 3600000);
+      
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before.getTime() + 3600000);
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should throw InvalidTTLFormatError for invalid format', () => {
+      expect(() => service.calculateExpiration('invalid')).toThrow(InvalidTTLFormatError);
+      expect(() => service.calculateExpiration('')).toThrow(InvalidTTLFormatError);
+      expect(() => service.calculateExpiration('1x')).toThrow(InvalidTTLFormatError);
+      expect(() => service.calculateExpiration('m')).toThrow(InvalidTTLFormatError);
+    });
+
+    it('should throw UnsupportedTTLUnitError for unsupported units', () => {
+      expect(() => service.calculateExpiration('1w')).toThrow(UnsupportedTTLUnitError);
+      expect(() => service.calculateExpiration('1y')).toThrow(UnsupportedTTLUnitError);
+    });
+  });
+
+  describe('toMilliseconds', () => {
+    it('should convert TTL to milliseconds', () => {
+      expect(service.toMilliseconds('1s')).toBe(1000);
+      expect(service.toMilliseconds('1m')).toBe(60000);
+      expect(service.toMilliseconds('1h')).toBe(3600000);
+      expect(service.toMilliseconds('1d')).toBe(86400000);
+      expect(service.toMilliseconds('30s')).toBe(30000);
+    });
+  });
+
+  describe('getSupportedUnits', () => {
+    it('should return supported units', () => {
+      const units = service.getSupportedUnits();
+      expect(units).toEqual(['s', 'm', 'h', 'd']);
+    });
+  });
+});

--- a/backend/src/modules/identity/domain/services/token-expiration.service.ts
+++ b/backend/src/modules/identity/domain/services/token-expiration.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+
+export class InvalidTTLFormatError extends Error {
+  constructor(ttl: string) {
+    super(`Invalid TTL format: ${ttl}. Expected format: <number><unit> where unit is s, m, h, or d`);
+    this.name = 'InvalidTTLFormatError';
+  }
+}
+
+export class UnsupportedTTLUnitError extends Error {
+  constructor(unit: string) {
+    super(`Unsupported TTL unit: ${unit}. Supported units: s (seconds), m (minutes), h (hours), d (days)`);
+    this.name = 'UnsupportedTTLUnitError';
+  }
+}
+
+export interface TTLCalculationResult {
+  expiresAt: Date;
+  milliseconds: number;
+}
+
+@Injectable()
+export class TokenExpirationService {
+  private readonly unitMap: Record<string, number> = {
+    s: 1000,        
+    m: 60000,       
+    h: 3600000,     
+    d: 86400000,    
+  };
+
+  /**
+   * Calculate expiration date based on TTL string
+   * @param ttl - Time to live string in format: <number><unit> (e.g., "15m", "2h", "7d")
+   * @param fromDate - Optional base date (defaults to current date)
+   * @returns TTLCalculationResult with expiration date and duration in milliseconds
+   * @throws {InvalidTTLFormatError} When TTL format is invalid
+   * @throws {UnsupportedTTLUnitError} When TTL unit is not supported
+   */
+  calculateExpiration(ttl: string, fromDate: Date = new Date()): TTLCalculationResult {
+    this.validateTTLFormat(ttl);
+
+    const { value, unit } = this.parseTTL(ttl);
+    
+    if (!this.unitMap[unit]) {
+      throw new UnsupportedTTLUnitError(unit);
+    }
+
+    const milliseconds = value * this.unitMap[unit];
+    const expiresAt = new Date(fromDate.getTime() + milliseconds);
+
+    return { expiresAt, milliseconds };
+  }
+
+  /**
+   * Parse TTL string into value and unit
+   */
+  private parseTTL(ttl: string): { value: number; unit: string } {
+    const match = ttl.match(/^(\d+)([smhd])$/);
+    if (!match) {
+      throw new InvalidTTLFormatError(ttl);
+    }
+
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+
+    return { value, unit };
+  }
+
+  /**
+   * Validate TTL string format
+   */
+  private validateTTLFormat(ttl: string): void {
+    if (typeof ttl !== 'string') {
+      throw new InvalidTTLFormatError(String(ttl));
+    }
+
+    if (!ttl.match(/^\d+[smhd]$/)) {
+      throw new InvalidTTLFormatError(ttl);
+    }
+  }
+
+  /**
+   * Get supported TTL units
+   */
+  getSupportedUnits(): string[] {
+    return Object.keys(this.unitMap);
+  }
+
+  /**
+   * Convert TTL to milliseconds
+   */
+  toMilliseconds(ttl: string): number {
+    const { value, unit } = this.parseTTL(ttl);
+    
+    if (!this.unitMap[unit]) {
+      throw new UnsupportedTTLUnitError(unit);
+    }
+
+    return value * this.unitMap[unit];
+  }
+}

--- a/backend/src/modules/identity/identity.module.ts
+++ b/backend/src/modules/identity/identity.module.ts
@@ -10,6 +10,7 @@ import {
   HASHER,
   TOKEN_SERVICE,
   AUTHZ_PORT,
+  TOKEN_EXPIRATION_SERVICE,
 } from './tokens';
 import { UserPrismaRepository } from './infrastructure/persistence/user.prisma.repository';
 import { SessionPrismaRepository } from './infrastructure/persistence/session.prisma.repository';
@@ -19,6 +20,7 @@ import { GetMeUseCase } from './application/queries/get-me.usecase';
 import { JwtStrategy } from './infrastructure/http/jwt.strategy';
 import { RbacAuthzAdapter } from './infrastructure/authz/rbac-authz.adapter';
 import { RbacModule } from '../rbac/rbac.module';
+import { TokenExpirationService } from './domain/services/token-expiration.service';
 
 @Module({
   imports: [PrismaModule, forwardRef(() => RbacModule)],
@@ -29,13 +31,26 @@ import { RbacModule } from '../rbac/rbac.module';
     LogoutUseCase,
     GetMeUseCase,
     JwtStrategy,
+    
     { provide: USER_REPO, useClass: UserPrismaRepository },
     { provide: SESSION_REPO, useClass: SessionPrismaRepository },
+    
     { provide: HASHER, useClass: BcryptHasher },
+    
     { provide: TOKEN_SERVICE, useClass: JwtTokenService },
+    
+    TokenExpirationService,
+    { provide: TOKEN_EXPIRATION_SERVICE, useClass: TokenExpirationService },
+    
     RbacAuthzAdapter,
     { provide: AUTHZ_PORT, useClass: RbacAuthzAdapter },
   ],
-  exports: [TOKEN_SERVICE, USER_REPO, HASHER],
+  exports: [
+    TOKEN_SERVICE, 
+    USER_REPO, 
+    HASHER,
+    TOKEN_EXPIRATION_SERVICE,
+    TokenExpirationService,
+  ],
 })
 export class IdentityModule {}

--- a/backend/src/modules/identity/tokens.ts
+++ b/backend/src/modules/identity/tokens.ts
@@ -3,3 +3,4 @@ export const SESSION_REPO = Symbol('SessionRepositoryPort');
 export const HASHER = Symbol('PasswordHasherPort');
 export const TOKEN_SERVICE = Symbol('TokenServicePort');
 export const AUTHZ_PORT = Symbol('AuthorizationPort');
+export const TOKEN_EXPIRATION_SERVICE = Symbol('TokenExpirationService');

--- a/backend/src/modules/interviewChat/interview.module.ts
+++ b/backend/src/modules/interviewChat/interview.module.ts
@@ -25,5 +25,8 @@ import { InterviewExamDbModule } from '../interview-exam-db/interview-exam-db.mo
     DeepseekAdapter,
     { provide: LLM_PORT, useExisting: DeepseekAdapter },
   ],
+  exports: [
+    DsIntService,
+  ],
 })
 export class InterviewModule {}


### PR DESCRIPTION
## Qué se hizo
Se extrajo la lógica de cálculo de tiempo de tokens de los casos de uso a un servicio de dominio `TokenExpirationService`.

## Por qué
- **Separar responsabilidades**: Los casos de uso deben orquestar, no calcular
- **Evitar código duplicado**: Misma lógica en login y refresh  
- **Mejor mantenibilidad**: Cambios en un solo lugar
- **Más testeable**: Servicio fácil de probar aisladamente