### PR TITLE
refactor(auth): separate client info extraction from controller

### DIFF
--- a/backend/src/modules/identity/identity.module.ts
+++ b/backend/src/modules/identity/identity.module.ts
@@ -19,6 +19,7 @@ import { GetMeUseCase } from './application/queries/get-me.usecase';
 import { JwtStrategy } from './infrastructure/http/jwt.strategy';
 import { RbacAuthzAdapter } from './infrastructure/authz/rbac-authz.adapter';
 import { RbacModule } from '../rbac/rbac.module';
+import { RequestInfoService } from './infrastructure/request-info.service';
 
 @Module({
   imports: [PrismaModule, forwardRef(() => RbacModule)],
@@ -29,6 +30,7 @@ import { RbacModule } from '../rbac/rbac.module';
     LogoutUseCase,
     GetMeUseCase,
     JwtStrategy,
+    RequestInfoService,
     { provide: USER_REPO, useClass: UserPrismaRepository },
     { provide: SESSION_REPO, useClass: SessionPrismaRepository },
     { provide: HASHER, useClass: BcryptHasher },

--- a/backend/src/modules/identity/infrastructure/request-info.service.spec.ts
+++ b/backend/src/modules/identity/infrastructure/request-info.service.spec.ts
@@ -1,0 +1,97 @@
+import { RequestInfoService } from './request-info.service';
+import type { Request } from 'express';
+
+describe('RequestInfoService', () => {
+  let service: RequestInfoService;
+  let mockRequest: Partial<Request>;
+
+  beforeEach(() => {
+    service = new RequestInfoService();
+    mockRequest = {
+      headers: {},
+      socket: {} as any,
+    } as Partial<Request>;
+  });
+
+  describe('extractClientInfo', () => {
+    it('should extract IP from X-Forwarded-For header', () => {
+      mockRequest.headers = {
+        'x-forwarded-for': '192.168.1.1, 10.0.0.1',
+      };
+
+      const result = service.extractClientInfo(
+        mockRequest as Request,
+        'test-agent',
+      );
+
+      expect(result).toEqual({
+        ip: '192.168.1.1',
+        userAgent: 'test-agent',
+      });
+    });
+
+    it('should extract IP from socket.remoteAddress when X-Forwarded-For is not available', () => {
+      mockRequest.headers = {};
+      mockRequest.socket = { remoteAddress: '127.0.0.1' } as any;
+
+      const result = service.extractClientInfo(
+        mockRequest as Request,
+        'test-agent',
+      );
+
+      expect(result).toEqual({
+        ip: '127.0.0.1',
+        userAgent: 'test-agent',
+      });
+    });
+
+    it('should handle missing IP gracefully', () => {
+      mockRequest.headers = {};
+      mockRequest.socket = {} as any;
+
+      const result = service.extractClientInfo(
+        mockRequest as Request,
+        'test-agent',
+      );
+
+      expect(result).toEqual({
+        ip: undefined,
+        userAgent: 'test-agent',
+      });
+    });
+
+    it('should handle missing user agent gracefully', () => {
+      mockRequest.headers = {
+        'x-forwarded-for': '192.168.1.1',
+      };
+
+      const result = service.extractClientInfo(mockRequest as Request);
+
+      expect(result).toEqual({
+        ip: '192.168.1.1',
+        userAgent: undefined,
+      });
+    });
+
+    it('should trim whitespace from X-Forwarded-For IP', () => {
+      mockRequest.headers = {
+        'x-forwarded-for': ' 192.168.1.1 , 10.0.0.1',
+      };
+
+      const result = service.extractClientInfo(mockRequest as Request);
+
+      expect(result.ip).toBe('192.168.1.1');
+    });
+
+    it('should handle empty X-Forwarded-For header', () => {
+      mockRequest.headers = {
+        'x-forwarded-for': '',
+      };
+      mockRequest.socket = { remoteAddress: '127.0.0.1' } as any;
+
+      const result = service.extractClientInfo(mockRequest as Request);
+
+      expect(result.ip).toBe('127.0.0.1');
+    });
+  });
+});

--- a/backend/src/modules/identity/infrastructure/request-info.service.ts
+++ b/backend/src/modules/identity/infrastructure/request-info.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+
+export interface ClientInfo {
+  ip?: string;
+  userAgent?: string;
+}
+
+@Injectable()
+export class RequestInfoService {
+  /**
+   * Extracts client information from the HTTP request
+   * @param req - Express request object
+   * @param userAgent - User-Agent header value
+   * @returns Object containing client IP and user agent
+   */
+  extractClientInfo(req: Request, userAgent?: string): ClientInfo {
+    const ip = this.extractClientIp(req);
+
+    return {
+      ip,
+      userAgent,
+    };
+  }
+
+  /**
+   * Extracts client IP address from request headers and socket
+   * Prioritizes X-Forwarded-For header for proxy/load balancer scenarios
+   * @param req - Express request object
+   * @returns Client IP address or undefined if not available
+   */
+  private extractClientIp(req: Request): string | undefined {
+    // Check X-Forwarded-For header first (for proxy/load balancer scenarios)
+    const forwardedFor = req.headers['x-forwarded-for'] as string;
+    if (forwardedFor) {
+      // X-Forwarded-For can contain multiple IPs, take the first one (client's real IP)
+      return forwardedFor.split(',')[0]?.trim();
+    }
+
+    // Fallback to direct connection IP
+    return req.socket.remoteAddress || undefined;
+  }
+}


### PR DESCRIPTION
# Cambios realizados

- Se crea `RequestInfoService` para manejar la extracción de **IP** y **User-Agent**.  
- Se elimina la lógica de negocio de `AuthController` siguiendo los principios de arquitectura hexagonal.  
- Se agregan pruebas unitarias completas para `RequestInfoService`.  
- Se actualiza `IdentityModule` para registrar el nuevo servicio.  

---

# Nota importante

**BREAKING CHANGE:**  
`AuthController` ahora depende de `RequestInfoService`.  
