### PR TITLE
refactor[#131]: extract ExamManagementPage logic into a hook and split UI into components

### DIFF
--- a/client/src/pages/professor/exams/ExamManagementPage.tsx
+++ b/client/src/pages/professor/exams/ExamManagementPage.tsx
@@ -1,90 +1,38 @@
-import { Card, Typography, theme } from 'antd';
-import { useParams } from 'react-router-dom';
-import { useEffect } from 'react';
-import ExamTable from '../../../components/exams/ExamTable';
-import { useExamsStore } from '../../../store/examsStore';
 import PageTemplate from '../../../components/PageTemplate';
 import GlobalScrollbar from '../../../components/GlobalScrollbar';
-import useCourses from '../../../hooks/useCourses'; 
-
-
-const { Title, Text } = Typography;
+import useExamManagement from './management/useExamManagement';
+import StatsCards from './management/components/StatsCards';
+import ExamsTableWrapper from './management/components/ExamsTable';
 
 export default function ExamManagementPage() {
-  const { token } = theme.useToken();
-  const exams = useExamsStore((s) => s.exams);
-  const { courseId } = useParams<{ courseId: string }>();
-  
-  // Hook para obtener información del curso
-  const { actualCourse, getCourseByID } = useCourses();
-
-  // Obtener información del curso si tenemos courseId
-  useEffect(() => {
-    if (courseId && !actualCourse) {
-      getCourseByID(courseId);
-    }
-  }, [courseId, actualCourse, getCourseByID]);
-
-  const total = exams.length;
-  const published = exams.filter((e) => e.status === "published").length;
-  const scheduled = exams.filter((e) => e.status === "scheduled").length;
-
-  // Breadcrumbs dinámicos basados en contexto
-  const breadcrumbs = courseId 
-    ? [
-        { label: 'Inicio', href: '/' },
-        { label: 'Materias', href: '/professor/courses' },
-        { label: actualCourse?.name || 'Curso', href: `/professor/courses/${courseId}/periods` },
-        { label: 'Exámenes' }
-      ]
-    : [
-        { label: 'Inicio', href: '/' },
-        { label: 'Materias', href: '/professor/courses' },
-        { label: 'Gestión de Exámenes'}
-      ];
+  const {
+    exams,
+    total,
+    published,
+    scheduled,
+    breadcrumbs,
+    onEdit,
+  } = useExamManagement();
 
   return (
     <PageTemplate
-          title="Exámenes"
-          subtitle="Gestiona todos los exámenes que creaste"
-          breadcrumbs={breadcrumbs}
-        >
-
+      title="Exámenes"
+      subtitle="Gestiona todos los exámenes que creaste"
+      breadcrumbs={breadcrumbs}
+    >
       <GlobalScrollbar />
-      <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card style={{ borderLeft: `4px solid ${token.colorPrimary}` }}>
-          <Title level={4} style={{ margin: 0 }}>
-            Total
-          </Title>
-          <Text type="secondary">{total} exámenes</Text>
-        </Card>
-        <Card style={{ borderLeft: `4px solid ${token.colorSuccess}` }}>
-          <Title level={4} style={{ margin: 0 }}>
-            Publicados
-          </Title>
-          <Text type="secondary">{published}</Text>
-        </Card>
-        <Card style={{ borderLeft: `4px solid ${token.colorInfo}` }}>
-          <Title level={4} style={{ margin: 0 }}>
-            Programados
-          </Title>
-          <Text type="secondary">{scheduled}</Text>
-        </Card>
-      </div>
+
+      <StatsCards total={total} published={published} scheduled={scheduled} />
 
       <div id="tabla-examenes" style={{ marginTop: 24 }}>
-        <ExamTable data={exams} />
+        <ExamsTableWrapper data={exams} />
       </div>
 
-        <div id="tabla-examenes">
-          <ExamTable
-            data={exams}
-            onEdit={() => { window.location.href = '/professor/exams/create'; }}
-          />
-        </div>
+      <div id="tabla-examenes">
+        <ExamsTableWrapper data={exams} onEdit={onEdit} />
+      </div>
 
-        <div id="fin-examenes" />
-
+      <div id="fin-examenes" />
     </PageTemplate>
   );
 }

--- a/client/src/pages/professor/exams/management/components/ExamsTable.tsx
+++ b/client/src/pages/professor/exams/management/components/ExamsTable.tsx
@@ -1,0 +1,10 @@
+import ExamTable from '../../../../../components/exams/ExamTable';
+
+type Props = {
+  data: any[];
+  onEdit?: () => void; 
+};
+
+export default function ExamsTableWrapper({ data, onEdit }: Props) {
+  return <ExamTable data={data} {...(onEdit ? { onEdit } : {})} />;
+}

--- a/client/src/pages/professor/exams/management/components/StatsCards.tsx
+++ b/client/src/pages/professor/exams/management/components/StatsCards.tsx
@@ -1,0 +1,31 @@
+import { Card, Typography, theme } from 'antd';
+const { Title, Text } = Typography;
+
+type Props = {
+  total: number;
+  published: number;
+  scheduled: number;
+};
+
+export default function StatsCards({ total, published, scheduled }: Props) {
+  const { token } = theme.useToken();
+
+  return (
+    <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-4">
+      <Card style={{ borderLeft: `4px solid ${token.colorPrimary}` }}>
+        <Title level={4} style={{ margin: 0 }}>Total</Title>
+        <Text type="secondary">{total} exámenes</Text>
+      </Card>
+
+      <Card style={{ borderLeft: `4px solid ${token.colorSuccess}` }}>
+        <Title level={4} style={{ margin: 0 }}>Publicados</Title>
+        <Text type="secondary">{published}</Text>
+      </Card>
+
+      <Card style={{ borderLeft: `4px solid ${token.colorInfo}` }}>
+        <Title level={4} style={{ margin: 0 }}>Programados</Title>
+        <Text type="secondary">{scheduled}</Text>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/professor/exams/management/useExamManagement.ts
+++ b/client/src/pages/professor/exams/management/useExamManagement.ts
@@ -1,0 +1,54 @@
+import { useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useExamsStore } from '../../../../store/examsStore';
+import useCourses from '../../../../hooks/useCourses';
+
+export type Breadcrumb = { label: string; href?: string };
+
+export default function useExamManagement() {
+  const exams = useExamsStore((s) => s.exams);
+  const { courseId } = useParams<{ courseId: string }>();
+
+  const { actualCourse, getCourseByID } = useCourses();
+
+  useEffect(() => {
+    if (courseId && !actualCourse) {
+      getCourseByID(courseId);
+    }
+  }, [courseId, actualCourse, getCourseByID]);
+
+  const { total, published, scheduled } = useMemo(() => {
+    const total = exams.length;
+    const published = exams.filter((e: any) => e.status === 'published').length;
+    const scheduled = exams.filter((e: any) => e.status === 'scheduled').length;
+    return { total, published, scheduled };
+  }, [exams]);
+
+  const breadcrumbs: Breadcrumb[] = useMemo(() => {
+    return courseId
+      ? [
+          { label: 'Inicio', href: '/' },
+          { label: 'Materias', href: '/professor/courses' },
+          { label: actualCourse?.name || 'Curso', href: `/professor/courses/${courseId}/periods` },
+          { label: 'Exámenes' },
+        ]
+      : [
+          { label: 'Inicio', href: '/' },
+          { label: 'Materias', href: '/professor/courses' },
+          { label: 'Gestión de Exámenes' },
+        ];
+  }, [courseId, actualCourse?.name]);
+
+  const onEdit = () => {
+    window.location.href = '/professor/exams/create';
+  };
+
+  return {
+    exams,
+    total,
+    published,
+    scheduled,
+    breadcrumbs,
+    onEdit,
+  };
+}


### PR DESCRIPTION
# Descripción

Refactor de `ExamManagementPage` para extraer la lógica (fetch, filtros, paginación, acciones) a un custom hook y dividir la UI en componentes pequeños, sin cambiar el comportamiento existente.

## Cambios realizados

* Se creó `useExamManagement.ts` con:
  - Lectura de `exams` desde store
  - `useParams`
  - Integración con `useCourses`
  - `useEffect` para cargar curso
  - Cómputo de métricas (total/publicados/programados)
  - Breadcrumbs
  - `onEdit` 

* Se creó `components/StatsCards.tsx` para las tarjetas de métricas (misma UI)

* Se creó `components/ExamsTable.tsx` como wrapper del `components/exams/ExamTable` existente (sin modificarlo)

* `ExamManagementPage.tsx` queda delgada; consume el hook, renderiza StatsCards y ambas tablas manteniendo ids y textos.