### PR TITLE
test(UPB-240): Automatiza ProfessorHome con Cypress, mocks de login y…

### DIFF
--- a/client/cypress/e2e/professorhome.cy.js
+++ b/client/cypress/e2e/professorhome.cy.js
@@ -1,0 +1,107 @@
+/// <reference types="cypress" />
+
+const ensureDashboardLoaded = () => {
+  cy.location('pathname', { timeout: 10000 }).should('eq', '/');
+  cy.contains(/Dashboard/i).should('exist');
+};
+
+const stubProfessorNavigationApis = () => {
+  cy.intercept('GET', '**/academic/teacher/**', {
+    statusCode: 200,
+    body: {
+      code: 200,
+      data: {
+        id: 'teacher-1',
+        name: 'Ana',
+        lastname: 'Gonzalez',
+        email: 'docente@example.com',
+      },
+    },
+  }).as('getTeacherInfo');
+
+  cy.intercept('GET', '**/academic/course/by-teacher/**', {
+    statusCode: 200,
+    body: {
+      code: 200,
+      data: [],
+    },
+  }).as('getCoursesByTeacher');
+
+  cy.intercept('GET', '**/api/documents', {
+    statusCode: 200,
+    body: {
+      success: true,
+      message: '',
+      documents: [],
+      total: 0,
+    },
+  }).as('getDocuments');
+};
+
+describe('Professor Dashboard (UPB-240)', () => {
+  it('Carga correctamente el dashboard del profesor', () => {
+    cy.loginProfessor();
+    ensureDashboardLoaded();
+
+    cy.fixture('professor/counts.json').then(({ courses, students, activeExams }) => {
+      cy.get('[data-testid="prof-summary-courses"]').should('contain', String(courses));
+      cy.get('[data-testid="prof-summary-students"]').should('contain', String(students));
+      cy.get('[data-testid="prof-summary-active-exams"]').should('contain', String(activeExams));
+    });
+
+    cy.get('[data-testid="prof-upcoming-schedule"]').within(() => {
+      cy.contains(/Publish Midterm #2/i).should('exist');
+      cy.contains(/Grade Quiz #5/i).should('exist');
+    });
+  });
+
+  it('Permite navegar a las secciones principales', () => {
+    stubProfessorNavigationApis();
+
+    cy.loginProfessor();
+    ensureDashboardLoaded();
+
+    cy.get('a[href="/courses"]').click({ force: true });
+    cy.url().should('include', '/courses');
+    cy.wait('@getCoursesByTeacher');
+
+    cy.go('back');
+    ensureDashboardLoaded();
+
+    cy.get('a[href="/exams/create"]').click({ force: true });
+    cy.url().should('include', '/exams/create');
+    cy.wait('@getCoursesByTeacher');
+
+    cy.go('back');
+    ensureDashboardLoaded();
+
+    cy.get('a[href="/document"]').click({ force: true });
+    cy.url().should('include', '/document');
+    cy.wait('@getDocuments');
+
+    cy.go('back');
+    ensureDashboardLoaded();
+
+    cy.get('a[href="/settings"]').click({ force: true });
+    cy.url().should('include', '/settings');
+  });
+
+  it('Muestra placeholders mientras carga la data del dashboard', () => {
+    cy.loginProfessor({ mockClock: true });
+    ensureDashboardLoaded();
+
+    cy.get('[data-testid="prof-summary-courses"] .ant-skeleton').should('be.visible');
+    cy.get('[data-testid="prof-summary-students"] .ant-skeleton').should('be.visible');
+    cy.get('[data-testid="prof-summary-active-exams"] .ant-skeleton').should('be.visible');
+
+    cy.tick(600);
+    cy.get('[data-testid="prof-summary-courses"] .ant-skeleton').should('not.exist');
+    cy.get('[data-testid="prof-summary-students"] .ant-skeleton').should('not.exist');
+    cy.get('[data-testid="prof-summary-active-exams"] .ant-skeleton').should('not.exist');
+    cy.fixture('professor/counts.json').then(({ courses, students, activeExams }) => {
+      cy.get('[data-testid="prof-summary-courses"]').should('contain', String(courses));
+      cy.get('[data-testid="prof-summary-students"]').should('contain', String(students));
+      cy.get('[data-testid="prof-summary-active-exams"]').should('contain', String(activeExams));
+    });
+  });
+});

--- a/client/cypress/fixtures/professor/counts.json
+++ b/client/cypress/fixtures/professor/counts.json
@@ -1,0 +1,6 @@
+{
+  "courses": 3,
+  "students": 92,
+  "activeExams": 2,
+  "notifications": 2
+}

--- a/client/cypress/fixtures/professor/summary.json
+++ b/client/cypress/fixtures/professor/summary.json
@@ -1,0 +1,11 @@
+{
+  "coursesCount": 4,
+  "upcomingExams": [
+    { "course": "Algebra I", "date": "2025-11-05T14:00:00Z" },
+    { "course": "Física II", "date": "2025-11-12T14:00:00Z" }
+  ],
+  "notifications": [
+    { "id": "n1", "message": "Entrega de notas pendiente", "level": "warning" },
+    { "id": "n2", "message": "Solicitud de revisión: Sección B", "level": "info" }
+  ]
+}

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -35,3 +35,60 @@
 //     }
 //   }
 // }
+
+/// <reference types="cypress" />
+
+type LoginProfessorOptions = {
+  mockClock?: boolean;
+};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginProfessor(options?: LoginProfessorOptions): Chainable<void>;
+    }
+  }
+}
+
+Cypress.Commands.add('loginProfessor', (options: LoginProfessorOptions = {}) => {
+  const { mockClock = false } = options;
+
+  cy.intercept('POST', '**/auth/login', (req) => {
+    req.reply({
+      statusCode: 200,
+      body: {
+        accessToken: 'fake-access-token',
+        refreshToken: 'fake-refresh-token',
+        user: {
+          id: 'teacher-1',
+          email: 'docente@example.com',
+          name: 'Ana',
+          roles: ['docente'],
+        },
+      },
+    });
+  }).as('loginRequest');
+
+  cy.intercept('GET', '**/auth/me', {
+    statusCode: 200,
+    body: {
+      id: 'teacher-1',
+      email: 'docente@example.com',
+      name: 'Ana',
+      lastname: 'Gonzalez',
+      roles: ['docente'],
+    },
+  }).as('getCurrentUser');
+
+  if (mockClock) {
+    cy.clock(Date.now(), ['setTimeout', 'clearTimeout']);
+  }
+  cy.visit('http://localhost:5173/login');
+  cy.get('input[id="login_email"]').type('docente@example.com');
+  cy.get('input[id="login_password"]').type('Docente123!');
+  cy.get('button[type="submit"]').click();
+  cy.wait('@loginRequest');
+  cy.wait('@getCurrentUser');
+});
+
+export {};

--- a/client/src/pages/dashboard/ProfessorHome.tsx
+++ b/client/src/pages/dashboard/ProfessorHome.tsx
@@ -63,13 +63,13 @@ export default function ProfessorHome() {
 
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
-          <Card><Skeleton loading={loading} active><Statistic title="Courses" value={snap?.courses ?? 0} /></Skeleton></Card>
+          <Card data-testid="prof-summary-courses"><Skeleton loading={loading} active><Statistic title="Courses" value={snap?.courses ?? 0} /></Skeleton></Card>
         </Col>
         <Col xs={24} md={8}>
-          <Card><Skeleton loading={loading} active><Statistic title="Students" value={snap?.students ?? 0} /></Skeleton></Card>
+          <Card data-testid="prof-summary-students"><Skeleton loading={loading} active><Statistic title="Students" value={snap?.students ?? 0} /></Skeleton></Card>
         </Col>
         <Col xs={24} md={8}>
-          <Card><Skeleton loading={loading} active><Statistic title="Active exams" value={snap?.activeExams ?? 0} /></Skeleton></Card>
+          <Card data-testid="prof-summary-active-exams"><Skeleton loading={loading} active><Statistic title="Active exams" value={snap?.activeExams ?? 0} /></Skeleton></Card>
         </Col>
       </Row>
 
@@ -86,7 +86,7 @@ export default function ProfessorHome() {
           </Skeleton>
         </Card>
         <div className="lg:col-span-5 grid grid-rows-2 gap-4">
-          <Card title="Upcoming schedule" className="row-span-1">
+          <Card title="Upcoming schedule" className="row-span-1" data-testid="prof-upcoming-schedule">
             <Skeleton loading={loading} active>
               <List
                 dataSource={calendar}
@@ -102,7 +102,7 @@ export default function ProfessorHome() {
             </Skeleton>
           </Card>
 
-          <Card title="Question bank health" className="row-span-1">
+          <Card title="Question bank health" className="row-span-1" data-testid="prof-question-bank">
             <Skeleton loading={loading} active>
               <Row gutter={16}>
                 <Col span={8}><Statistic title="Topics" value={bankStats?.topics ?? 0} /></Col>


### PR DESCRIPTION
… data-testid estables
###  Objetivo
Automatizar los flujos críticos del dashboard del profesor (ruta `/`) validando:
- Widgets de resumen (cursos, estudiantes, exámenes activos, notificaciones)
- Navegación hacia módulos secundarios (Courses, Exams, Documents, Settings)
- Manejo de placeholders y errores

###  Cambios realizados
Archivos creados
- client/cypress/e2e/professorhome.cy.js: nuevo spec que automatiza el flujo completo del dashboard del profesor (login, validación de widgets, navegación, placeholders).
- client/cypress/fixtures/professor/summary.json: fixture con datos representativos del resumen (cursos, exámenes próximos, notificaciones).
- client/cypress/fixtures/professor/counts.json: fixture con datos reales mostrados en los widgets (3 cursos, 92 estudiantes, 2 exámenes activos).

Archivos modificados
- client/cypress/support/commands.ts: se amplió cy.loginProfessor() para interceptar /auth/login y /auth/me, simulando la sesión completa sin backend. Se añadió control de reloj (mockClock) y sincronización con las peticiones antes de continuar.
- client/src/pages/dashboard/ProfessorHome.tsx: se agregaron data-testid en las tarjetas de resumen y widgets laterales para permitir selectores estables en los tests de Cypress. No se alteró el diseño ni la lógica existente.

### Resultados
Todos los tests de `professorhome.cy.js` pasan exitosamente (3/3).  

### Evidencias
<img width="1440" height="900" alt="Screenshot 2025-10-26 at 12 28 41 PM" src="https://github.com/user-attachments/assets/ce5da371-057d-4858-8612-1a91b76f2796" />

