### PR TITLE
feat: centralize RBAC mappers and refactor repositories to use ports/…

### DIFF
--- a/backend/src/modules/rbac/domain/mappers/index.ts
+++ b/backend/src/modules/rbac/domain/mappers/index.ts
@@ -1,0 +1,2 @@
+export * from './role.mapper';
+export * from './permission.mapper';

--- a/backend/src/modules/rbac/domain/mappers/permission.mapper.spec.ts
+++ b/backend/src/modules/rbac/domain/mappers/permission.mapper.spec.ts
@@ -1,0 +1,148 @@
+import { PermissionMapper, PermissionPersistenceRecord, CreatePermissionData } from './permission.mapper';
+import { Permission } from '../entities/permission.entity';
+
+describe('PermissionMapper', () => {
+  describe('toDomain', () => {
+    it('should convert persistence record to domain entity', () => {
+      const record: PermissionPersistenceRecord = {
+        id: 'perm-1',
+        action: 'read',
+        resource: 'documents',
+        description: 'Read documents permission',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const result = PermissionMapper.toDomain(record);
+
+      expect(result).toBeInstanceOf(Permission);
+      expect(result.id).toBe('perm-1');
+      expect(result.action).toBe('read');
+      expect(result.resource).toBe('documents');
+      expect(result.description).toBe('Read documents permission');
+    });
+
+    it('should handle null description', () => {
+      const record: PermissionPersistenceRecord = {
+        id: 'perm-1',
+        action: 'write',
+        resource: 'files',
+        description: null,
+      };
+
+      const result = PermissionMapper.toDomain(record);
+
+      expect(result.description).toBeNull();
+    });
+  });
+
+  describe('toDomainList', () => {
+    it('should convert multiple persistence records to domain entities', () => {
+      const records: PermissionPersistenceRecord[] = [
+        { id: 'perm-1', action: 'read', resource: 'docs', description: 'Read docs' },
+        { id: 'perm-2', action: 'write', resource: 'files', description: null },
+      ];
+
+      const result = PermissionMapper.toDomainList(records);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBeInstanceOf(Permission);
+      expect(result[0].id).toBe('perm-1');
+      expect(result[1]).toBeInstanceOf(Permission);
+      expect(result[1].id).toBe('perm-2');
+    });
+
+    it('should return empty array for empty input', () => {
+      const result = PermissionMapper.toDomainList([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('toPersistenceCreate', () => {
+    it('should convert create data to persistence format', () => {
+      const data: CreatePermissionData = {
+        action: 'delete',
+        resource: 'users',
+        description: 'Delete users permission',
+      };
+
+      const result = PermissionMapper.toPersistenceCreate(data);
+
+      expect(result).toEqual({
+        action: 'delete',
+        resource: 'users',
+        description: 'Delete users permission',
+      });
+    });
+
+    it('should handle undefined description', () => {
+      const data: CreatePermissionData = {
+        action: 'create',
+        resource: 'posts',
+      };
+
+      const result = PermissionMapper.toPersistenceCreate(data);
+
+      expect(result).toEqual({
+        action: 'create',
+        resource: 'posts',
+        description: null,
+      });
+    });
+
+    it('should handle explicit null description', () => {
+      const data: CreatePermissionData = {
+        action: 'update',
+        resource: 'comments',
+        description: null,
+      };
+
+      const result = PermissionMapper.toPersistenceCreate(data);
+
+      expect(result).toEqual({
+        action: 'update',
+        resource: 'comments',
+        description: null,
+      });
+    });
+  });
+
+  describe('toPersistenceUpdate', () => {
+    it('should convert domain entity to persistence update format', () => {
+      const permission = new Permission('perm-1', 'manage', 'projects', 'Manage projects');
+
+      const result = PermissionMapper.toPersistenceUpdate(permission);
+
+      expect(result).toEqual({
+        action: 'manage',
+        resource: 'projects',
+        description: 'Manage projects',
+      });
+    });
+
+    it('should handle null description in domain entity', () => {
+      const permission = new Permission('perm-1', 'view', 'reports', null);
+
+      const result = PermissionMapper.toPersistenceUpdate(permission);
+
+      expect(result).toEqual({
+        action: 'view',
+        resource: 'reports',
+        description: null,
+      });
+    });
+
+    it('should handle undefined description in domain entity', () => {
+      const permission = new Permission('perm-1', 'export', 'data');
+
+      const result = PermissionMapper.toPersistenceUpdate(permission);
+
+      expect(result).toEqual({
+        action: 'export',
+        resource: 'data',
+        description: null,
+      });
+    });
+  });
+});

--- a/backend/src/modules/rbac/domain/mappers/permission.mapper.ts
+++ b/backend/src/modules/rbac/domain/mappers/permission.mapper.ts
@@ -1,0 +1,53 @@
+import { Permission } from '../entities/permission.entity';
+
+export interface PermissionPersistenceRecord {
+  id: string;
+  action: string;
+  resource: string;
+  description: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface CreatePermissionData {
+  action: string;
+  resource: string;
+  description?: string | null;
+}
+
+export class PermissionMapper {
+  
+  static toDomain(record: PermissionPersistenceRecord): Permission {
+    return new Permission(record.id, record.action, record.resource, record.description);
+  }
+
+  
+  static toDomainList(records: PermissionPersistenceRecord[]): Permission[] {
+    return records.map(record => this.toDomain(record));
+  }
+
+  static toPersistenceCreate(data: CreatePermissionData): {
+    action: string;
+    resource: string;
+    description: string | null;
+  } {
+    return {
+      action: data.action,
+      resource: data.resource,
+      description: data.description ?? null,
+    };
+  }
+
+  
+  static toPersistenceUpdate(permission: Permission): {
+    action: string;
+    resource: string;
+    description: string | null;
+  } {
+    return {
+      action: permission.action,
+      resource: permission.resource,
+      description: permission.description ?? null,
+    };
+  }
+}

--- a/backend/src/modules/rbac/domain/mappers/role.mapper.spec.ts
+++ b/backend/src/modules/rbac/domain/mappers/role.mapper.spec.ts
@@ -1,0 +1,136 @@
+import { RoleMapper, RolePersistenceRecord, CreateRoleData } from './role.mapper';
+import { Role } from '../entities/role.entity';
+
+describe('RoleMapper', () => {
+  describe('toDomain', () => {
+    it('should convert persistence record to domain entity', () => {
+      const record: RolePersistenceRecord = {
+        id: 'role-1',
+        name: 'admin',
+        description: 'Administrator role',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const result = RoleMapper.toDomain(record);
+
+      expect(result).toBeInstanceOf(Role);
+      expect(result.id).toBe('role-1');
+      expect(result.name).toBe('admin');
+      expect(result.description).toBe('Administrator role');
+    });
+
+    it('should handle null description', () => {
+      const record: RolePersistenceRecord = {
+        id: 'role-1',
+        name: 'user',
+        description: null,
+      };
+
+      const result = RoleMapper.toDomain(record);
+
+      expect(result.description).toBeNull();
+    });
+  });
+
+  describe('toDomainList', () => {
+    it('should convert multiple persistence records to domain entities', () => {
+      const records: RolePersistenceRecord[] = [
+        { id: 'role-1', name: 'admin', description: 'Admin role' },
+        { id: 'role-2', name: 'user', description: null },
+      ];
+
+      const result = RoleMapper.toDomainList(records);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBeInstanceOf(Role);
+      expect(result[0].id).toBe('role-1');
+      expect(result[1]).toBeInstanceOf(Role);
+      expect(result[1].id).toBe('role-2');
+    });
+
+    it('should return empty array for empty input', () => {
+      const result = RoleMapper.toDomainList([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('toPersistenceCreate', () => {
+    it('should convert create data to persistence format', () => {
+      const data: CreateRoleData = {
+        name: 'moderator',
+        description: 'Moderator role',
+      };
+
+      const result = RoleMapper.toPersistenceCreate(data);
+
+      expect(result).toEqual({
+        name: 'moderator',
+        description: 'Moderator role',
+      });
+    });
+
+    it('should handle undefined description', () => {
+      const data: CreateRoleData = {
+        name: 'guest',
+      };
+
+      const result = RoleMapper.toPersistenceCreate(data);
+
+      expect(result).toEqual({
+        name: 'guest',
+        description: null,
+      });
+    });
+
+    it('should handle explicit null description', () => {
+      const data: CreateRoleData = {
+        name: 'guest',
+        description: null,
+      };
+
+      const result = RoleMapper.toPersistenceCreate(data);
+
+      expect(result).toEqual({
+        name: 'guest',
+        description: null,
+      });
+    });
+  });
+
+  describe('toPersistenceUpdate', () => {
+    it('should convert domain entity to persistence update format', () => {
+      const role = new Role('role-1', 'updated-admin', 'Updated admin role');
+
+      const result = RoleMapper.toPersistenceUpdate(role);
+
+      expect(result).toEqual({
+        name: 'updated-admin',
+        description: 'Updated admin role',
+      });
+    });
+
+    it('should handle null description in domain entity', () => {
+      const role = new Role('role-1', 'basic-user', null);
+
+      const result = RoleMapper.toPersistenceUpdate(role);
+
+      expect(result).toEqual({
+        name: 'basic-user',
+        description: null,
+      });
+    });
+
+    it('should handle undefined description in domain entity', () => {
+      const role = new Role('role-1', 'basic-user');
+
+      const result = RoleMapper.toPersistenceUpdate(role);
+
+      expect(result).toEqual({
+        name: 'basic-user',
+        description: null,
+      });
+    });
+  });
+});

--- a/backend/src/modules/rbac/domain/mappers/role.mapper.ts
+++ b/backend/src/modules/rbac/domain/mappers/role.mapper.ts
@@ -1,0 +1,45 @@
+import { Role } from '../entities/role.entity';
+
+export interface RolePersistenceRecord {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface CreateRoleData {
+  name: string;
+  description?: string | null;
+}
+
+export class RoleMapper {
+
+  static toDomain(record: RolePersistenceRecord): Role {
+    return new Role(record.id, record.name, record.description);
+  }
+
+  static toDomainList(records: RolePersistenceRecord[]): Role[] {
+    return records.map(record => this.toDomain(record));
+  }
+
+  static toPersistenceCreate(data: CreateRoleData): {
+    name: string;
+    description: string | null;
+  } {
+    return {
+      name: data.name,
+      description: data.description ?? null,
+    };
+  }
+
+  static toPersistenceUpdate(role: Role): {
+    name: string;
+    description: string | null;
+  } {
+    return {
+      name: role.name,
+      description: role.description ?? null,
+    };
+  }
+}

--- a/backend/src/modules/rbac/infrastructure/persistence/permission.prisma.repository.ts
+++ b/backend/src/modules/rbac/infrastructure/persistence/permission.prisma.repository.ts
@@ -2,32 +2,32 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../../core/prisma/prisma.service';
 import { PermissionRepositoryPort } from '../../domain/ports/permission.repository.port';
 import { Permission } from '../../domain/entities/permission.entity';
+import { PermissionMapper } from '../../domain/mappers';
 
 @Injectable()
 export class PermissionPrismaRepository implements PermissionRepositoryPort {
   constructor(private readonly prisma: PrismaService) {}
   async findById(id: string) {
     const p = await this.prisma.permission.findUnique({ where: { id } });
-    return p ? new Permission(p.id, p.action, p.resource, p.description) : null;
+    return p ? PermissionMapper.toDomain(p) : null;
   }
   async findByActionResource(action: string, resource: string) {
     const p = await this.prisma.permission.findUnique({
       where: { action_resource: { action, resource } },
     });
-    return p ? new Permission(p.id, p.action, p.resource, p.description) : null;
+    return p ? PermissionMapper.toDomain(p) : null;
   }
   async create(action: string, resource: string, description?: string | null) {
+    const createData = PermissionMapper.toPersistenceCreate({ action, resource, description });
     const p = await this.prisma.permission.create({
-      data: { action, resource, description },
+      data: createData,
     });
-    return new Permission(p.id, p.action, p.resource, p.description);
+    return PermissionMapper.toDomain(p);
   }
   async list() {
     const rows = await this.prisma.permission.findMany({
       orderBy: [{ resource: 'asc' }, { action: 'asc' }],
     });
-    return rows.map(
-      (p) => new Permission(p.id, p.action, p.resource, p.description),
-    );
+    return PermissionMapper.toDomainList(rows);
   }
 }

--- a/backend/src/modules/rbac/infrastructure/persistence/role.prisma.repository.ts
+++ b/backend/src/modules/rbac/infrastructure/persistence/role.prisma.repository.ts
@@ -8,7 +8,7 @@ import {
   PermissionNotFoundError,
   RoleTransactionError,
 } from '../../domain/errors/role.errors';
-import { RoleMapper } from '../../domain/mappers';
+import { RoleMapper, PermissionMapper } from '../../domain/mappers';
 
 @Injectable()
 export class RolePrismaRepository implements RoleRepositoryPort {
@@ -141,8 +141,6 @@ export class RolePrismaRepository implements RoleRepositoryPort {
       distinct: ['id'],
     });
 
-    return permissions.map(
-      (p) => new Permission(p.id, p.action, p.resource, p.description),
-    );
+    return PermissionMapper.toDomainList(permissions);
   }
 }


### PR DESCRIPTION
## Cambios principales

- Se crean **`RoleMapper`** y **`PermissionMapper`** en `domain/mappers` para centralizar la conversión de entidades.  
- Se refactoriza **`RolePrismaRepository`** para utilizar **`RoleMapper`** en lugar de instanciar entidades directamente.  
- Se refactoriza **`PermissionPrismaRepository`** para utilizar **`PermissionMapper`** en lugar de instanciación directa.  
- Se añaden **pruebas unitarias exhaustivas** para ambos mapeadores (20 pruebas en total).  
- Se corrige el mock en **`create-permission.usecase.spec.ts`** para incluir todos los métodos requeridos del repositorio.  
- Se elimina cualquier instancia directa de entidades (`new Entity()`) dentro de la capa de infraestructura.  
- Se mantiene la **separación de responsabilidades**, en cumplimiento con los principios de **arquitectura hexagonal**.  

https://linear.app/upb/issue/UPB-176/backend-centralizar-mappers-y-adaptar-repositorios-a-portsadapters