### PR TITLE
Feat-250-consolidate-repo-mappers

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -697,4 +697,6 @@ model RbacAudit {
   before    Json?
   after     Json?
   reason    String?
+
+  @@map("rbac_audit")
 }

--- a/backend/src/modules/interview-exam-db/domain/entities/interview-question.entity.ts
+++ b/backend/src/modules/interview-exam-db/domain/entities/interview-question.entity.ts
@@ -1,0 +1,40 @@
+import { Course } from '../../../academic_management/domain/entities/course.entity';
+import { Document } from '../../../repository_documents/domain/entities/document.entity';
+
+export class InterviewQuestion {
+  constructor(
+    public readonly id: string,
+    public readonly courseId: string,
+    public readonly docId: string,
+    public readonly json: Record<string, any>,
+    public readonly type: string,
+    public readonly lastUsedAt: Date | null,
+    public readonly createdAt: Date,
+    public readonly course?: Course,
+    public readonly document?: Document,
+  ) {}
+
+  static create(props: {
+    id: string;
+    courseId: string;
+    docId: string;
+    json: Record<string, any>;
+    type: string;
+    lastUsedAt?: Date | null;
+    createdAt?: Date;
+    course?: Course;
+    document?: Document;
+  }): InterviewQuestion {
+    return new InterviewQuestion(
+      props.id,
+      props.courseId,
+      props.docId,
+      props.json,
+      props.type,
+      props.lastUsedAt || null,
+      props.createdAt || new Date(),
+      props.course,
+      props.document,
+    );
+  }
+}

--- a/backend/src/modules/interview-exam-db/domain/mappers/__tests__/interview-question.mapper.spec.ts
+++ b/backend/src/modules/interview-exam-db/domain/mappers/__tests__/interview-question.mapper.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from '@jest/globals';
+import { InterviewQuestionMapper, InterviewQuestionRawData } from '../interview-question.mapper';
+import { Course } from '../../../../academic_management/domain/entities/course.entity';
+import { Document, DocumentStatus } from '../../../../repository_documents/domain/entities/document.entity';
+
+describe('InterviewQuestionMapper', () => {
+  const mockDate = new Date('2025-10-30T12:00:00Z');
+  const mockRawData: InterviewQuestionRawData = {
+    id: '1',
+    courseId: 'course-1',
+    docId: 'doc-1',
+    json: { question: 'Test question?' },
+    type: 'multiple-choice',
+    lastUsedAt: mockDate,
+    createdAt: mockDate,
+    course: {
+      id: 'course-1',
+      name: 'Test Course',
+      isActive: true,
+      teacherId: 'teacher-1',
+      createdAt: mockDate,
+      updatedAt: mockDate,
+    },
+    document: {
+      id: 'doc-1',
+      originalName: 'test-doc.pdf',
+      storedName: 'test-doc-1234.pdf',
+      s3Key: '/test/doc.pdf',
+      size: 1024,
+      contentType: 'application/pdf',
+      fileHash: 'hash123',
+      textHash: 'texthash123',
+      extractedText: 'Test content',
+      status: DocumentStatus.UPLOADED,
+      uploadedBy: 'user-1',
+      courseId: 'course-1',
+      classId: null,
+      pageCount: 1,
+      documentTitle: 'Test Document',
+      documentAuthor: 'Test Author',
+      language: 'es',
+      uploadedAt: mockDate,
+      updatedAt: mockDate,
+    },
+  };
+
+  describe('toDomain', () => {
+    it('should map raw data to domain entity correctly', () => {
+      const domainEntity = InterviewQuestionMapper.toDomain(mockRawData);
+
+      expect(domainEntity.id).toBe(mockRawData.id);
+      expect(domainEntity.courseId).toBe(mockRawData.courseId);
+      expect(domainEntity.docId).toBe(mockRawData.docId);
+      expect(domainEntity.json).toEqual(mockRawData.json);
+      expect(domainEntity.type).toBe(mockRawData.type);
+      expect(domainEntity.lastUsedAt).toBe(mockRawData.lastUsedAt);
+      expect(domainEntity.createdAt).toBe(mockRawData.createdAt);
+
+      // Course mapping
+      expect(domainEntity.course).toBeDefined();
+      expect(domainEntity.course?.id).toBe(mockRawData.course?.id);
+      expect(domainEntity.course?.name).toBe(mockRawData.course?.name);
+      expect(domainEntity.course?.isActive).toBe(mockRawData.course?.isActive);
+      expect(domainEntity.course?.teacherId).toBe(mockRawData.course?.teacherId);
+
+      // Document mapping
+      expect(domainEntity.document).toBeDefined();
+      expect(domainEntity.document?.id).toBe(mockRawData.document?.id);
+      expect(domainEntity.document?.fileName).toBe(mockRawData.document?.originalName);
+      expect(domainEntity.document?.originalName).toBe(mockRawData.document?.originalName);
+      expect(domainEntity.document?.url).toBe(mockRawData.document?.s3Key);
+      expect(domainEntity.document?.mimeType).toBe(mockRawData.document?.contentType);
+      expect(domainEntity.document?.size).toBe(mockRawData.document?.size);
+      expect(domainEntity.document?.courseId).toBe(mockRawData.document?.courseId);
+      expect(domainEntity.document?.documentTitle).toBe(mockRawData.document?.documentTitle);
+      expect(domainEntity.document?.documentAuthor).toBe(mockRawData.document?.documentAuthor);
+    });
+
+    it('should handle null lastUsedAt', () => {
+      const rawDataWithNullLastUsed = {
+        ...mockRawData,
+        lastUsedAt: null,
+      };
+
+      const domainEntity = InterviewQuestionMapper.toDomain(rawDataWithNullLastUsed);
+      expect(domainEntity.lastUsedAt).toBeNull();
+    });
+
+    it('should handle missing optional fields', () => {
+      const rawDataWithoutOptionals = {
+        id: '1',
+        courseId: 'course-1',
+        docId: 'doc-1',
+        json: { question: 'Test question?' },
+        type: 'multiple-choice',
+        lastUsedAt: mockDate,
+        createdAt: mockDate,
+      };
+
+      const domainEntity = InterviewQuestionMapper.toDomain(rawDataWithoutOptionals);
+      expect(domainEntity.course).toBeUndefined();
+      expect(domainEntity.document).toBeUndefined();
+    });
+  });
+
+  describe('toDomainArray', () => {
+    it('should map array of raw data to array of domain entities', () => {
+      const rawArray = [mockRawData, { ...mockRawData, id: '2' }];
+      const domainArray = InterviewQuestionMapper.toDomainArray(rawArray);
+
+      expect(domainArray).toHaveLength(2);
+      expect(domainArray[0].id).toBe('1');
+      expect(domainArray[1].id).toBe('2');
+    });
+  });
+
+  describe('toPersistence', () => {
+    it('should map domain entity to raw data without course and document', () => {
+      const domainEntity = InterviewQuestionMapper.toDomain(mockRawData);
+      const persistenceData = InterviewQuestionMapper.toPersistence(domainEntity);
+
+      expect(persistenceData.id).toBe(domainEntity.id);
+      expect(persistenceData.courseId).toBe(domainEntity.courseId);
+      expect(persistenceData.docId).toBe(domainEntity.docId);
+      expect(persistenceData.json).toEqual(domainEntity.json);
+      expect(persistenceData.type).toBe(domainEntity.type);
+      expect(persistenceData.lastUsedAt).toBe(domainEntity.lastUsedAt);
+      expect(persistenceData.createdAt).toBe(domainEntity.createdAt);
+      expect((persistenceData as any).course).toBeUndefined();
+      expect((persistenceData as any).document).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/modules/interview-exam-db/domain/mappers/interview-question.mapper.ts
+++ b/backend/src/modules/interview-exam-db/domain/mappers/interview-question.mapper.ts
@@ -1,0 +1,102 @@
+import { Course } from '../../../academic_management/domain/entities/course.entity';
+import { Document, DocumentStatus } from '../../../repository_documents/domain/entities/document.entity';
+import { InterviewQuestion } from '../entities/interview-question.entity';
+
+export type InterviewQuestionRawData = {
+  id: string;
+  courseId: string;
+  docId: string;
+  json: Record<string, any> | null;
+  type: string;
+  lastUsedAt: Date | null;
+  createdAt: Date;
+  course?: {
+    id: string;
+    name: string;
+    isActive: boolean;
+    teacherId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  document?: {
+    id: string;
+    originalName: string;
+    storedName: string;
+    s3Key: string;
+    size: number;
+    contentType: string;
+    fileHash: string;
+    textHash: string | null;
+    extractedText: string | null;
+    status: DocumentStatus;
+    uploadedBy: string;
+    courseId: string | null;
+    classId: string | null;
+    pageCount: number | null;
+    documentTitle: string | null;
+    documentAuthor: string | null;
+    language: string | null;
+    uploadedAt: Date;
+    updatedAt: Date;
+  };
+};
+
+export class InterviewQuestionMapper {
+  static toDomain(raw: InterviewQuestionRawData): InterviewQuestion {
+    return InterviewQuestion.create({
+      id: raw.id,
+      courseId: raw.courseId,
+      docId: raw.docId,
+      json: raw.json || {},
+      type: raw.type,
+      lastUsedAt: raw.lastUsedAt,
+      createdAt: raw.createdAt,
+      course: raw.course ? {
+        id: raw.course.id,
+        name: raw.course.name,
+        isActive: raw.course.isActive,
+        teacherId: raw.course.teacherId,
+        createdAt: raw.course.createdAt,
+        updatedAt: raw.course.updatedAt,
+      } as Course : undefined,
+      document: raw.document ? new Document(
+        raw.document.id,
+        raw.document.originalName, // fileName
+        raw.document.originalName, // originalName
+        raw.document.contentType, // mimeType
+        raw.document.size,
+        raw.document.s3Key, // url/path
+        raw.document.s3Key,
+        raw.document.fileHash,
+        raw.document.uploadedBy,
+        raw.document.status,
+        raw.document.extractedText || '', // extractedText
+        raw.document.textHash || '', // textHash
+        raw.document.pageCount || 0, // pageCount
+        raw.document.documentTitle || '', // documentTitle
+        raw.document.documentAuthor || '', // documentAuthor
+        raw.document.language || '', // language
+        raw.document.courseId || undefined,
+        raw.document.classId || undefined,
+        raw.document.uploadedAt,
+        raw.document.updatedAt
+      ) : undefined,
+    });
+  }
+
+  static toDomainArray(rawArray: InterviewQuestionRawData[]): InterviewQuestion[] {
+    return rawArray.map(raw => this.toDomain(raw));
+  }
+
+  static toPersistence(entity: InterviewQuestion): Record<string, any> {
+    return {
+      id: entity.id,
+      courseId: entity.courseId,
+      docId: entity.docId,
+      json: entity.json || null,
+      type: entity.type,
+      lastUsedAt: entity.lastUsedAt,
+      createdAt: entity.createdAt,
+    };
+  }
+}

--- a/backend/src/modules/interview-exam-db/domain/ports/interview-question.repository.port.ts
+++ b/backend/src/modules/interview-exam-db/domain/ports/interview-question.repository.port.ts
@@ -1,0 +1,32 @@
+import { InterviewQuestion } from '../../domain/entities/interview-question.entity';
+
+export interface InterviewQuestionRepositoryPort {
+  create(question: InterviewQuestion): Promise<InterviewQuestion>;
+  findAll(): Promise<InterviewQuestion[]>;
+  findOne(id: string): Promise<InterviewQuestion>;
+  findByCourseId(courseId: string, page?: number, limit?: number): Promise<{
+    data: InterviewQuestion[];
+    meta: {
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+    };
+  }>;
+  findByDocId(docId: string, page?: number, limit?: number): Promise<{
+    data: InterviewQuestion[];
+    meta: {
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+    };
+  }>;
+  findByCourseAndDocument(courseId: string, docId: string): Promise<InterviewQuestion[]>;
+  update(id: string, question: Partial<InterviewQuestion>): Promise<InterviewQuestion>;
+  remove(id: string): Promise<void>;
+  markAsUsed(id: string): Promise<InterviewQuestion>;
+  getRecentlyUsed(limit?: number): Promise<InterviewQuestion[]>;
+  getRecent(limit?: number): Promise<InterviewQuestion[]>;
+  findByCourseAndDocumentAndType(courseId: string, docId: string, type: string): Promise<InterviewQuestion[]>;
+}

--- a/backend/src/modules/interview-exam-db/infrastructure/persistence/prisma-interview-question.repository.ts
+++ b/backend/src/modules/interview-exam-db/infrastructure/persistence/prisma-interview-question.repository.ts
@@ -1,0 +1,260 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/core/prisma/prisma.service';
+import { InterviewQuestion } from '../../domain/entities/interview-question.entity';
+import { InterviewQuestionMapper, InterviewQuestionRawData } from '../../domain/mappers/interview-question.mapper';
+import { InterviewQuestionRepositoryPort } from '../../domain/ports/interview-question.repository.port';
+import {
+  CreateInterviewQuestionDto,
+  UpdateInterviewQuestionDto,
+} from '../../dtos/interview-exam.dto';
+
+@Injectable()
+export class PrismaInterviewQuestionRepository implements InterviewQuestionRepositoryPort {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(question: InterviewQuestion): Promise<InterviewQuestion> {
+    try {
+      const rawData = InterviewQuestionMapper.toPersistence(question);
+      const created = await this.prisma.interviewQuestion.create({
+        data: {
+          id: rawData.id,
+          courseId: rawData.courseId,
+          docId: rawData.docId,
+          type: rawData.type,
+          json: rawData.json as any,
+          lastUsedAt: rawData.lastUsedAt,
+          createdAt: rawData.createdAt,
+        },
+        include: {
+          course: true,
+          document: true,
+        },
+      }) as InterviewQuestionRawData;
+      return InterviewQuestionMapper.toDomain(created);
+    } catch (error) {
+      if (error.code === 'P2002') {
+        throw new ConflictException(
+          'Ya existe una pregunta de entrevista con estos datos',
+        );
+      }
+      if (error.code === 'P2003') {
+        throw new BadRequestException(
+          'El curso o documento referenciado no existe',
+        );
+      }
+      throw error;
+    }
+  }
+
+  async findAll(): Promise<InterviewQuestion[]> {
+    const questions = await this.prisma.interviewQuestion.findMany({
+      include: {
+        course: true,
+        document: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    }) as InterviewQuestionRawData[];
+    return InterviewQuestionMapper.toDomainArray(questions);
+  }
+
+  async findOne(id: string): Promise<InterviewQuestion> {
+    const question = await this.prisma.interviewQuestion.findUnique({
+      where: { id },
+      include: {
+        course: true,
+        document: true,
+      },
+    }) as InterviewQuestionRawData;
+
+    if (!question) {
+      throw new NotFoundException(
+        `Pregunta de entrevista con ID ${id} no encontrada`,
+      );
+    }
+
+    return InterviewQuestionMapper.toDomain(question);
+  }
+
+  async findByCourseId(courseId: string, page: number = 1, limit: number = 10) {
+    const skip = (page - 1) * limit;
+
+    const [questions, total] = await Promise.all([
+      this.prisma.interviewQuestion.findMany({
+        where: { courseId },
+        include: {
+          course: true,
+          document: true,
+        },
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }) as Promise<InterviewQuestionRawData[]>,
+      this.prisma.interviewQuestion.count({ where: { courseId } }),
+    ]);
+
+    return {
+      data: InterviewQuestionMapper.toDomainArray(questions),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findByDocId(docId: string, page: number = 1, limit: number = 10) {
+    const skip = (page - 1) * limit;
+
+    const [questions, total] = await Promise.all([
+      this.prisma.interviewQuestion.findMany({
+        where: { docId },
+        include: {
+          course: true,
+          document: true,
+        },
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }) as Promise<InterviewQuestionRawData[]>,
+      this.prisma.interviewQuestion.count({ where: { docId } }),
+    ]);
+
+    return {
+      data: InterviewQuestionMapper.toDomainArray(questions),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findByCourseAndDocument(courseId: string, docId: string): Promise<InterviewQuestion[]> {
+    const questions = await this.prisma.interviewQuestion.findMany({
+      where: {
+        courseId,
+        docId,
+      },
+      include: {
+        course: true,
+        document: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    }) as InterviewQuestionRawData[];
+    return InterviewQuestionMapper.toDomainArray(questions);
+  }
+
+  async update(id: string, questionData: Partial<InterviewQuestion>): Promise<InterviewQuestion> {
+    try {
+      const updated = await this.prisma.interviewQuestion.update({
+        where: { id },
+        data: {
+          json: questionData.json,
+          lastUsedAt: questionData.lastUsedAt,
+        },
+        include: {
+          course: true,
+          document: true,
+        },
+      }) as InterviewQuestionRawData;
+      return InterviewQuestionMapper.toDomain(updated);
+    } catch (error) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException(
+          `Pregunta de entrevista con ID ${id} no encontrada`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      await this.prisma.interviewQuestion.delete({
+        where: { id },
+      });
+    } catch (error) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException(
+          `Pregunta de entrevista con ID ${id} no encontrada`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async markAsUsed(id: string): Promise<InterviewQuestion> {
+    try {
+      const updated = await this.prisma.interviewQuestion.update({
+        where: { id },
+        data: {
+          lastUsedAt: new Date(),
+        },
+        include: {
+          course: true,
+          document: true,
+        },
+      }) as InterviewQuestionRawData;
+      return InterviewQuestionMapper.toDomain(updated);
+    } catch (error) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException(
+          `Pregunta de entrevista con ID ${id} no encontrada`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async getRecentlyUsed(limit: number = 10): Promise<InterviewQuestion[]> {
+    const questions = await this.prisma.interviewQuestion.findMany({
+      where: {
+        lastUsedAt: {
+          not: null,
+        },
+      },
+      include: {
+        course: true,
+        document: true,
+      },
+      orderBy: { lastUsedAt: 'desc' },
+      take: limit,
+    }) as InterviewQuestionRawData[];
+    return InterviewQuestionMapper.toDomainArray(questions);
+  }
+
+  async getRecent(limit: number = 10): Promise<InterviewQuestion[]> {
+    const questions = await this.prisma.interviewQuestion.findMany({
+      include: {
+        course: true,
+        document: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    }) as InterviewQuestionRawData[];
+    return InterviewQuestionMapper.toDomainArray(questions);
+  }
+
+  async findByCourseAndDocumentAndType(courseId: string, docId: string, type: string): Promise<InterviewQuestion[]> {
+    const questions = await this.prisma.interviewQuestion.findMany({
+      where: {
+        courseId,
+        docId,
+        type,
+      },
+      include: {
+        course: true,
+        document: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    }) as InterviewQuestionRawData[];
+    return InterviewQuestionMapper.toDomainArray(questions);
+  }
+}

--- a/backend/src/modules/interview-exam-db/interview-exam-db.module.ts
+++ b/backend/src/modules/interview-exam-db/interview-exam-db.module.ts
@@ -1,11 +1,20 @@
 import { Module } from '@nestjs/common';
-import { IntExamRepository } from './int-exam/int-exam.repository';
 import { PrismaModule } from 'src/core/prisma/prisma.module';
 import { ChatHistoryRepository } from './int-exam/chatH.repository';
+import { PrismaInterviewQuestionRepository } from './infrastructure/persistence/prisma-interview-question.repository';
 
 @Module({
   imports: [PrismaModule],
-  providers: [IntExamRepository, ChatHistoryRepository],
-  exports: [IntExamRepository, ChatHistoryRepository],
+  providers: [
+    {
+      provide: 'INTERVIEW_QUESTION_REPOSITORY',
+      useClass: PrismaInterviewQuestionRepository,
+    },
+    ChatHistoryRepository,
+  ],
+  exports: [
+    'INTERVIEW_QUESTION_REPOSITORY',
+    ChatHistoryRepository,
+  ],
 })
 export class InterviewExamDbModule {}


### PR DESCRIPTION
# Consolidación de Repositorios y Mappers

Implementación del **patrón Repositorio y Mapper** para la entidad `InterviewQuestion` en el proyecto **Learning-Agent**, siguiendo los principios de **Arquitectura Hexagonal** y **Clean Architecture**.

* **Capa de Dominio**

  * Entidad inmutable `InterviewQuestion` con método de fábrica `create()`.
  * Tipado fuerte y manejo seguro de campos nulos.

* **Mapper**

  * `InterviewQuestionMapper` con métodos `toDomain()`, `toDomainArray()` y `toPersistence()`.
  * Conversión consistente de fechas y campos opcionales.

* **Puerto del Repositorio**

  * `InterviewQuestionRepositoryPort` con operaciones CRUD esenciales.
  * Desacoplamiento total entre dominio e infraestructura.

* **Infraestructura**

  * `PrismaInterviewQuestionRepository` implementando el puerto mediante Prisma.
  * Manejo robusto de errores y conversiones.

* **Inyección de Dependencias**

  * Registro del provider `INTERVIEW_QUESTION_REPOSITORY` en `interview-exam-db.module.ts`.

* **Testing**

  * Pruebas unitarias con cobertura completa del mapper y validación de tipos.

## Estructura del Código

```
src/modules/interview-exam-db/
├── domain/
│   ├── entities/
│   ├── mappers/
│   └── ports/
├── infrastructure/persistence/
└── interview-exam-db.module.ts
```
La consolidación mejora la arquitectura del módulo, refuerza la mantenibilidad y garantiza una base sólida para futuras extensiones, alineada con los principios de Clean Architecture.

---

## issue 250
https://linear.app/upb/issue/UPB-250/backend-interview-exam-db-extraer-y-unificar-mappers-para-resultados
