### PR TITLE
feat:add DeadLetter retry handling and tests

### DIFF
--- a/backend/prisma/migrations/20251031183522_add_dead_letter_table/migration.sql
+++ b/backend/prisma/migrations/20251031183522_add_dead_letter_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "public"."DeadLetter" (
+    "id" SERIAL NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "jobType" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "errorMessage" TEXT,
+    "attempts" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DeadLetter_pkey" PRIMARY KEY ("id")
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -137,6 +137,19 @@ model UserSession {
   @@index([userId, expiresAt])
 }
 
+model DeadLetter {
+  id           String   @id @default(uuid())
+  jobId        String
+  documentId   String
+  jobType      String
+  payload      Json?
+  errorMessage String?
+  attempts     Int       @default(0)
+  createdAt    DateTime  @default(now())
+}
+
+
+
 model Document {
   id            String         @id @default(uuid())
   originalName  String

--- a/backend/src/modules/repository_documents/domain/services/processing-job.service.ts
+++ b/backend/src/modules/repository_documents/domain/services/processing-job.service.ts
@@ -4,7 +4,16 @@ import {
   ProcessingStatus,
 } from '../entities/processing-job.entity';
 
+import { DeadLetterRepository } from '../../infrastructure/persistence/prisma-dead-letter.repository';
+import { RETRY_CONFIG } from '../../infrastructure/config/retry.config';
+import { getBackoffDelay } from '../../infrastructure/services/retry.utils';
+
+/**
+ * Service to manage job lifecycle and retry/dead-letter logic.
+ */
 export class ProcessingJobService {
+  private static deadLetterRepo = new DeadLetterRepository();
+
   /**
    * Creates a new processing job
    */
@@ -174,7 +183,52 @@ export class ProcessingJobService {
   }
 
   /**
-   * Checks if the job is in a terminal state (completed or failed)
+   * Executes a job with retry and backoff policy
+   */
+  static async executeWithRetry(
+    job: ProcessingJob,
+    handler: (job: ProcessingJob) => Promise<void>,
+  ): Promise<void> {
+    let attempt = 0;
+
+    while (attempt < RETRY_CONFIG.maxAttempts) {
+      try {
+        console.log(`[JOB] Starting job ${job.id}, attempt ${attempt + 1}`);
+        const started = this.start(job);
+        await handler(started);
+
+        const completed = this.complete(started);
+        console.log(`[JOB] Job ${job.id} completed successfully`);
+        return;
+      } catch (error) {
+        attempt++;
+        const delay = getBackoffDelay(attempt);
+        console.warn(
+          `[JOB] Job ${job.id} failed (attempt ${attempt}): ${error}. Retrying in ${delay.toFixed(
+            0,
+          )}ms`,
+        );
+
+        if (attempt >= RETRY_CONFIG.maxAttempts) {
+          console.error(`[JOB] Job ${job.id} exceeded retry limit. Moving to dead-letter.`);
+          await this.deadLetterRepo.save({
+            jobId: job.id,
+            documentId: job.documentId,
+            jobType: job.jobType,
+            errorMessage: (error as Error).message,
+            attempts: attempt,
+            payload: job.jobDetails,
+          });
+          return;
+        }
+
+        await new Promise((res) => setTimeout(res, delay));
+      }
+    }
+  }
+
+  /**
+   * Checks if the job is in a terminal state
    */
   static isTerminal(job: ProcessingJob): boolean {
     return (
@@ -184,23 +238,14 @@ export class ProcessingJobService {
     );
   }
 
-  /**
-   * Checks if the job is running
-   */
   static isRunning(job: ProcessingJob): boolean {
     return job.status === ProcessingStatus.RUNNING;
   }
 
-  /**
-   * Checks if the job can be retried
-   */
   static canRetry(job: ProcessingJob): boolean {
     return job.status === ProcessingStatus.FAILED;
   }
 
-  /**
-   * Checks if the job is pending
-   */
   static isPending(job: ProcessingJob): boolean {
     return (
       job.status === ProcessingStatus.PENDING ||
@@ -208,19 +253,12 @@ export class ProcessingJobService {
     );
   }
 
-  /**
-   * Calculates the execution time of the job
-   */
   static getExecutionTime(job: ProcessingJob): number | null {
     if (!job.startedAt) return null;
-
     const endTime = job.completedAt || new Date();
     return endTime.getTime() - job.startedAt.getTime();
   }
 
-  /**
-   * Validates state transitions
-   */
   static canTransitionTo(
     currentStatus: ProcessingStatus,
     newStatus: ProcessingStatus,

--- a/backend/src/modules/repository_documents/domain/services/processing-job.service.ts
+++ b/backend/src/modules/repository_documents/domain/services/processing-job.service.ts
@@ -12,7 +12,15 @@ import { getBackoffDelay } from '../../infrastructure/services/retry.utils';
  * Service to manage job lifecycle and retry/dead-letter logic.
  */
 export class ProcessingJobService {
-  private static deadLetterRepo = new DeadLetterRepository();
+  // DeadLetterRepository is injected at module initialization to avoid direct instantiation
+  private static deadLetterRepo: DeadLetterRepository;
+
+  /**
+   * Set the DeadLetterRepository implementation (called by module provider at startup)
+   */
+  static setDeadLetterRepo(repo: DeadLetterRepository) {
+    this.deadLetterRepo = repo;
+  }
 
   /**
    * Creates a new processing job

--- a/backend/src/modules/repository_documents/infrastructure/config/retry.config.ts
+++ b/backend/src/modules/repository_documents/infrastructure/config/retry.config.ts
@@ -1,0 +1,6 @@
+export const RETRY_CONFIG = {
+  maxAttempts: 5,
+  baseDelayMs: 1000,
+  maxDelayMs: 30000,
+  jitter: true,
+};

--- a/backend/src/modules/repository_documents/infrastructure/http/admin-dead-letters.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/admin-dead-letters.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Query, ParseIntPipe } from '@nestjs/common';
+import { DeadLetterRepository } from '../persistence/prisma-dead-letter.repository';
+
+@Controller('admin')
+export class AdminDeadLettersController {
+  constructor(private readonly deadLetterRepo: DeadLetterRepository) {}
+
+  @Get('dead-letters')
+  async getDeadLetters(
+    @Query('page', ParseIntPipe) page = 1,
+    @Query('limit', ParseIntPipe) limit = 20,
+  ) {
+    const safePage = Number.isNaN(Number(page)) || page < 1 ? 1 : page;
+    const safeLimit = Number.isNaN(Number(limit)) || limit < 1 ? 20 : limit;
+
+    const skip = (safePage - 1) * safeLimit;
+    const take = safeLimit;
+
+    const [data, total] = await Promise.all([
+      this.deadLetterRepo.findAll({ skip, take }),
+      this.deadLetterRepo.count(),
+    ]);
+
+    return {
+      page: safePage,
+      limit: safeLimit,
+      total,
+      data,
+    };
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/persistence/prisma-dead-letter.repository.ts
+++ b/backend/src/modules/repository_documents/infrastructure/persistence/prisma-dead-letter.repository.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+export class DeadLetterRepository {
+  async save(data: {
+    jobId: string;
+    documentId: string;
+    jobType: string;
+    payload?: any;
+    errorMessage?: string;
+    attempts: number;
+  }) {
+    return prisma.deadLetter.create({
+      data,
+    });
+  }
+
+  async findAll() {
+    return prisma.deadLetter.findMany();
+  }
+
+  async clear() {
+    return prisma.deadLetter.deleteMany();
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/persistence/prisma-dead-letter.repository.ts
+++ b/backend/src/modules/repository_documents/infrastructure/persistence/prisma-dead-letter.repository.ts
@@ -1,7 +1,10 @@
-import { PrismaClient } from '@prisma/client';
-const prisma = new PrismaClient();
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
 
+@Injectable()
 export class DeadLetterRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
   async save(data: {
     jobId: string;
     documentId: string;
@@ -10,16 +13,23 @@ export class DeadLetterRepository {
     errorMessage?: string;
     attempts: number;
   }) {
-    return prisma.deadLetter.create({
-      data,
+    return this.prisma.deadLetter.create({ data });
+  }
+
+  async findAll(options?: { skip?: number; take?: number }) {
+    const { skip, take } = options || {};
+    return this.prisma.deadLetter.findMany({
+      skip,
+      take,
+      orderBy: { createdAt: 'desc' },
     });
   }
 
-  async findAll() {
-    return prisma.deadLetter.findMany();
+  async count() {
+    return this.prisma.deadLetter.count();
   }
 
   async clear() {
-    return prisma.deadLetter.deleteMany();
+    return this.prisma.deadLetter.deleteMany();
   }
 }

--- a/backend/src/modules/repository_documents/infrastructure/services/retry.utils.ts
+++ b/backend/src/modules/repository_documents/infrastructure/services/retry.utils.ts
@@ -1,0 +1,12 @@
+import { RETRY_CONFIG } from "../config/retry.config";
+
+export function getBackoffDelay(attempt: number): number {
+  const { baseDelayMs, maxDelayMs, jitter } = RETRY_CONFIG;
+  let delay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+
+  if (jitter) {
+    const random = Math.random() * delay * 0.2; 
+    delay = delay + (Math.random() > 0.5 ? random : -random);
+  }
+  return Math.max(0, delay);
+}

--- a/backend/src/modules/repository_documents/test/processing-job.executeWithRetry.integration.spec.ts
+++ b/backend/src/modules/repository_documents/test/processing-job.executeWithRetry.integration.spec.ts
@@ -1,0 +1,56 @@
+import { Test } from '@nestjs/testing';
+import { PrismaModule } from '../../../../core/prisma/prisma.module';
+import { DocumentsModule } from '../../documents.module';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { DeadLetterRepository } from '../infrastructure/persistence/prisma-dead-letter.repository';
+import { ProcessingJobService } from '../domain/services/processing-job.service';
+import { ProcessingType } from '../domain/entities/processing-job.entity';
+import * as retryUtils from '../infrastructure/services/retry.utils';
+
+describe('ProcessingJobService.executeWithRetry - integration', () => {
+  let moduleRef: any;
+  let prisma: PrismaService;
+  let deadLetterRepo: DeadLetterRepository;
+
+  beforeAll(async () => {
+    // speed up retries
+    jest.spyOn(retryUtils, 'getBackoffDelay').mockReturnValue(0);
+
+    moduleRef = await Test.createTestingModule({
+      imports: [PrismaModule, DocumentsModule],
+    }).compile();
+
+    prisma = moduleRef.get(PrismaService);
+    deadLetterRepo = moduleRef.get(DeadLetterRepository);
+
+    // ensure clean slate
+    await prisma.deadLetter.deleteMany();
+
+    ProcessingJobService.setDeadLetterRepo(deadLetterRepo);
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await moduleRef.close();
+  });
+
+  it('creates a dead-letter row after failing max attempts', async () => {
+    const jobId = 'job-int-1';
+    const job = ProcessingJobService.create(
+      jobId,
+      'doc-int-1',
+      ProcessingType.TEXT_EXTRACTION,
+      { testing: true },
+    );
+
+    const handler = async () => {
+      throw new Error('integration-handler-failure');
+    };
+
+    await ProcessingJobService.executeWithRetry(job, handler);
+
+    const rows = await prisma.deadLetter.findMany({ where: { jobId } });
+    expect(rows.length).toBe(1);
+    expect(rows[0].jobId).toBe(jobId);
+  });
+});

--- a/backend/src/modules/repository_documents/test/processing-job.executeWithRetry.unit.spec.ts
+++ b/backend/src/modules/repository_documents/test/processing-job.executeWithRetry.unit.spec.ts
@@ -1,0 +1,43 @@
+import { ProcessingJobService } from '../domain/services/processing-job.service';
+import { ProcessingType } from '../domain/entities/processing-job.entity';
+import { RETRY_CONFIG } from '../infrastructure/config/retry.config';
+import * as retryUtils from '../infrastructure/services/retry.utils';
+
+describe('ProcessingJobService.executeWithRetry - unit', () => {
+  beforeAll(() => {
+    // speed up retries by removing backoff
+    jest.spyOn(retryUtils, 'getBackoffDelay').mockReturnValue(0);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('persists a dead-letter after exceeding max attempts', async () => {
+    const mockSave = jest.fn().mockResolvedValue({ id: 'mock-dead' });
+    const mockRepo: any = { save: mockSave };
+
+    // Inject mock repo
+    ProcessingJobService.setDeadLetterRepo(mockRepo);
+
+    const job = ProcessingJobService.create(
+      'job-unit-1',
+      'doc-unit-1',
+      ProcessingType.TEXT_EXTRACTION,
+      { foo: 'bar' },
+    );
+
+    const handler = jest.fn().mockRejectedValue(new Error('handler-failed'));
+
+    await ProcessingJobService.executeWithRetry(job, handler);
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'job-unit-1',
+        documentId: 'doc-unit-1',
+        attempts: RETRY_CONFIG.maxAttempts,
+      }),
+    );
+  });
+});

--- a/backend/src/modules/repository_documents/test/processing-job.retry.spec.ts
+++ b/backend/src/modules/repository_documents/test/processing-job.retry.spec.ts
@@ -1,0 +1,75 @@
+import { ProcessingJobService } from '../domain/services/processing-job.service';
+import { ProcessingJob, ProcessingStatus, ProcessingType } from '../domain/entities/processing-job.entity';
+import { DeadLetterRepository } from '../infrastructure/persistence/prisma-dead-letter.repository';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+describe('ProcessingJob retry and dead-letter handling', () => {
+ 
+  let saveSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    saveSpy = jest
+      .spyOn(DeadLetterRepository.prototype, 'save')
+      .mockImplementation(async (data: any) => ({ id: 'mock-id', ...data }));
+  });
+
+  afterAll(async () => {
+    saveSpy.mockRestore();
+    await prisma.$disconnect();
+  });
+
+  it('debe mover el job a DeadLetter después de exceder el límite de reintentos', async () => {
+   
+    const job = ProcessingJobService.create(
+      'job-test-1',
+      'doc-123',
+      ProcessingType.TEXT_EXTRACTION, 
+      { test: true }
+    );
+
+    let currentJob = job;
+    const MAX_RETRIES = 3;
+    let attempt = 0;
+
+    while (attempt < MAX_RETRIES) {
+      try {
+       
+        throw new Error(`Simulated worker failure #${attempt + 1}`);
+      } catch (err: any) {
+        attempt++;
+
+        if (attempt < MAX_RETRIES) {
+  
+          const failed = ProcessingJobService.fail(currentJob, err.message);
+          currentJob = ProcessingJobService.retry(failed);
+        } else {
+       
+          const failedFinal = ProcessingJobService.fail(currentJob, err.message);
+
+        
+          await new DeadLetterRepository().save({
+            jobId: failedFinal.id,
+            documentId: failedFinal.documentId,
+            jobType: failedFinal.jobType,
+            payload: failedFinal.jobDetails,
+            errorMessage: failedFinal.errorMessage,
+            attempts: attempt,
+          });
+
+          currentJob = failedFinal;
+        }
+      }
+    }
+
+    
+    expect(currentJob.status).toBe(ProcessingStatus.FAILED);
+
+   
+    expect(saveSpy).toHaveBeenCalled();
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: 'job-test-1', attempts: MAX_RETRIES }),
+    );
+  });
+});


### PR DESCRIPTION
Esta PR agrega soporte para el manejo de dead letters en el sistema de workers.
Se incluye una nueva tabla en Prisma (DeadLetter) y la lógica correspondiente para registrar los jobs fallidos que superan el número máximo de reintentos.

Cambios principales:

Creación de la tabla DeadLetter mediante migración Prisma.

Implementación de PrismaDeadLetterRepository para persistir los registros.

Actualización del worker para capturar fallos y mover los jobs a la tabla DeadLetter tras alcanzar el límite de reintentos.

Adición de un test de integración que fuerza fallos en un worker y valida que el job se registre correctamente en DeadLetter después del límite.