### PR TITLE
Fix/int-exam-service-spec

### DIFF
--- a/backend/src/modules/interview-exam-db/int-exam/int-exam.service.spec.ts
+++ b/backend/src/modules/interview-exam-db/int-exam/int-exam.service.spec.ts
@@ -1,18 +1,113 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { IntExamService } from './int-exam.repository';
+import { IntExamRepository } from './int-exam.repository';
+import { PrismaService } from 'src/core/prisma/prisma.service';
+import { CreateInterviewQuestionDto, UpdateInterviewQuestionDto } from '../dtos/interview-exam.dto';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 
-describe('IntExamService', () => {
-  let service: IntExamService;
+describe('IntExamRepository (unit)', () => {
+  let service: IntExamRepository;
+  let mockPrisma: any;
 
   beforeEach(async () => {
+    mockPrisma = {
+      interviewQuestion: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        count: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [IntExamService],
+      providers: [
+        IntExamRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
     }).compile();
 
-    service = module.get<IntExamService>(IntExamService);
+    service = module.get<IntExamRepository>(IntExamRepository);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  afterEach(() => jest.resetAllMocks());
+
+  it('create should persist and return the created question', async () => {
+    const dto: CreateInterviewQuestionDto = {
+      courseId: 'course-1',
+      docId: 'doc-1',
+      type: 'open_question',
+      json: { q: 'hello' },
+    };
+
+    const created = { id: 'id-1', ...dto };
+    mockPrisma.interviewQuestion.create.mockResolvedValue(created);
+
+    const result = await service.create(dto);
+
+    expect(mockPrisma.interviewQuestion.create).toHaveBeenCalledWith({
+      data: {
+        courseId: dto.courseId,
+        docId: dto.docId,
+        json: dto.json,
+        type: dto.type,
+      },
+      include: { course: true, document: true },
+    });
+
+    expect(result).toBe(created);
+  });
+
+  it('create should throw ConflictException on unique constraint (P2002)', async () => {
+    const dto: CreateInterviewQuestionDto = {
+      courseId: 'course-1',
+      docId: 'doc-1',
+      type: 'open_question',
+    };
+
+    const err: any = new Error('unique');
+    err.code = 'P2002';
+    mockPrisma.interviewQuestion.create.mockRejectedValue(err);
+
+    await expect(service.create(dto)).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('findOne should return question when found', async () => {
+    const found = { id: 'id-2', courseId: 'c', docId: 'd' };
+    mockPrisma.interviewQuestion.findUnique.mockResolvedValue(found);
+
+    const res = await service.findOne('id-2');
+    expect(mockPrisma.interviewQuestion.findUnique).toHaveBeenCalledWith({
+      where: { id: 'id-2' },
+      include: { course: true, document: true },
+    });
+    expect(res).toBe(found);
+  });
+
+  it('findOne should throw NotFoundException when not found', async () => {
+    mockPrisma.interviewQuestion.findUnique.mockResolvedValue(null);
+    await expect(service.findOne('missing')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('findByCourseId returns paginated results and meta', async () => {
+    const questions = [{ id: 'q1' }, { id: 'q2' }];
+    mockPrisma.interviewQuestion.findMany.mockResolvedValue(questions);
+    mockPrisma.interviewQuestion.count.mockResolvedValue(2);
+
+    const res = await service.findByCourseId('course-1', 1, 10);
+    expect(res).toHaveProperty('data', questions);
+    expect(res).toHaveProperty('meta');
+    expect(res.meta.total).toBe(2);
+    expect(mockPrisma.interviewQuestion.findMany).toHaveBeenCalled();
+  });
+
+  it('update should throw NotFoundException when prisma throws P2025', async () => {
+    const err: any = new Error('not found');
+    err.code = 'P2025';
+    mockPrisma.interviewQuestion.update.mockRejectedValue(err);
+
+    const dto: UpdateInterviewQuestionDto = { json: { a: 1 } };
+    await expect(service.update('nope', dto)).rejects.toBeInstanceOf(NotFoundException);
   });
 });
+

--- a/backend/src/modules/interview-exam-db/int-exam/int-exam.service.spec.ts
+++ b/backend/src/modules/interview-exam-db/int-exam/int-exam.service.spec.ts
@@ -1,24 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { IntExamRepository } from './int-exam.repository';
 import { PrismaService } from 'src/core/prisma/prisma.service';
-import { CreateInterviewQuestionDto, UpdateInterviewQuestionDto } from '../dtos/interview-exam.dto';
 import { ConflictException, NotFoundException } from '@nestjs/common';
+import { createInterviewPrismaMock } from '../../../../test/helpers/prisma-mocks';
+import { sampleCreateDto, sampleUpdateDto } from '../../../../test/helpers/fixtures/interview-fixtures';
 
 describe('IntExamRepository (unit)', () => {
   let service: IntExamRepository;
   let mockPrisma: any;
 
   beforeEach(async () => {
-    mockPrisma = {
-      interviewQuestion: {
-        create: jest.fn(),
-        findMany: jest.fn(),
-        findUnique: jest.fn(),
-        count: jest.fn(),
-        update: jest.fn(),
-        delete: jest.fn(),
-      },
-    };
+    mockPrisma = createInterviewPrismaMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -33,13 +25,7 @@ describe('IntExamRepository (unit)', () => {
   afterEach(() => jest.resetAllMocks());
 
   it('create should persist and return the created question', async () => {
-    const dto: CreateInterviewQuestionDto = {
-      courseId: 'course-1',
-      docId: 'doc-1',
-      type: 'open_question',
-      json: { q: 'hello' },
-    };
-
+    const dto = sampleCreateDto;
     const created = { id: 'id-1', ...dto };
     mockPrisma.interviewQuestion.create.mockResolvedValue(created);
 
@@ -59,11 +45,7 @@ describe('IntExamRepository (unit)', () => {
   });
 
   it('create should throw ConflictException on unique constraint (P2002)', async () => {
-    const dto: CreateInterviewQuestionDto = {
-      courseId: 'course-1',
-      docId: 'doc-1',
-      type: 'open_question',
-    };
+    const dto = sampleCreateDto;
 
     const err: any = new Error('unique');
     err.code = 'P2002';
@@ -106,7 +88,7 @@ describe('IntExamRepository (unit)', () => {
     err.code = 'P2025';
     mockPrisma.interviewQuestion.update.mockRejectedValue(err);
 
-    const dto: UpdateInterviewQuestionDto = { json: { a: 1 } };
+    const dto = sampleUpdateDto;
     await expect(service.update('nope', dto)).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/backend/src/modules/interviewChat/test/dsInt.service.unit.spec.ts
+++ b/backend/src/modules/interviewChat/test/dsInt.service.unit.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DsIntService } from '../infrastructure/dsInt.service';
+import { LLM_PORT } from 'src/modules/llm/tokens';
+import { PROMPT_TEMPLATE_PORT } from 'src/modules/prompt-template/tokens';
+import { GetDocumentContentUseCase } from 'src/modules/repository_documents/application/queries/get-document-content.usecase';
+
+describe('DsIntService (unit)', () => {
+  let service: DsIntService;
+  let mockLlm: any;
+  let mockPrompt: any;
+  let mockRepo: any;
+  let mockGetDoc: any;
+
+  beforeEach(async () => {
+    mockLlm = { complete: jest.fn() };
+    mockPrompt = { render: jest.fn() };
+    mockRepo = {
+      findByCourseAndDocumentAndType: jest.fn(),
+      create: jest.fn(),
+    };
+    mockGetDoc = { execute: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DsIntService,
+        { provide: LLM_PORT, useValue: mockLlm },
+        { provide: PROMPT_TEMPLATE_PORT, useValue: mockPrompt },
+        { provide: 'INTERVIEW_QUESTION_REPOSITORY', useValue: mockRepo },
+        { provide: GetDocumentContentUseCase, useValue: mockGetDoc },
+      ],
+    }).compile();
+
+    service = module.get<DsIntService>(DsIntService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns a random question from repo when available and random > 0.5', async () => {
+    const repoQuestions = [
+      { json: { question: 'q1' } },
+      { json: { question: 'q2' } },
+    ];
+    mockRepo.findByCourseAndDocumentAndType.mockResolvedValue(repoQuestions);
+
+    // Force Math.random to > 0.5 to take DB path
+    const mathSpy = jest.spyOn(Math, 'random').mockReturnValue(0.6);
+
+    const res = await service.generateQuestion('course-1', 'doc-1');
+
+    expect(mockRepo.findByCourseAndDocumentAndType).toHaveBeenCalledWith(
+      'course-1',
+      'doc-1',
+      'open_question',
+    );
+    // Should return one of the repo question jsons
+    expect([{ question: 'q1' }, { question: 'q2' }]).toContainEqual(res as any);
+    expect(mockGetDoc.execute).not.toHaveBeenCalled();
+    expect(mockPrompt.render).not.toHaveBeenCalled();
+    expect(mockLlm.complete).not.toHaveBeenCalled();
+
+    mathSpy.mockRestore();
+  });
+
+  it('calls LLM and persists question when repo empty or random <= 0.5', async () => {
+    mockRepo.findByCourseAndDocumentAndType.mockResolvedValue([]);
+    mockGetDoc.execute.mockResolvedValue({ contenido: 'doc content' });
+    mockPrompt.render.mockResolvedValue('rendered-prompt');
+    const aiResponse = { text: JSON.stringify({ question: 'ai-generated' }) };
+    mockLlm.complete.mockResolvedValue(aiResponse);
+
+    // Force Math.random to <= 0.5 to take AI path
+    jest.spyOn(Math, 'random').mockReturnValue(0.4);
+
+    const res = await service.generateQuestion('course-1', 'doc-1');
+
+    expect(mockGetDoc.execute).toHaveBeenCalledWith({ docId: 'doc-1' });
+    expect(mockPrompt.render).toHaveBeenCalled();
+    expect(mockLlm.complete).toHaveBeenCalled();
+    expect(mockRepo.create).toHaveBeenCalled();
+    expect(res).toEqual({ question: 'ai-generated' });
+  });
+});

--- a/backend/test/helpers/fixtures/interview-fixtures.ts
+++ b/backend/test/helpers/fixtures/interview-fixtures.ts
@@ -1,0 +1,12 @@
+import { CreateInterviewQuestionDto, UpdateInterviewQuestionDto } from '../../../src/modules/interview-exam-db/dtos/interview-exam.dto';
+
+export const sampleCreateDto: CreateInterviewQuestionDto = {
+  courseId: 'course-1',
+  docId: 'doc-1',
+  type: 'open_question',
+  json: { q: 'hello' },
+};
+
+export const sampleUpdateDto: UpdateInterviewQuestionDto = {
+  json: { a: 1 },
+};

--- a/backend/test/helpers/prisma-mocks.ts
+++ b/backend/test/helpers/prisma-mocks.ts
@@ -1,0 +1,12 @@
+export function createInterviewPrismaMock() {
+  return {
+    interviewQuestion: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      count: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+}


### PR DESCRIPTION
Refactorización los tests de int-exam.service.spec.ts para usar mocks de Prisma y eliminar dependencias reales de base de datos.
Ahora las pruebas son deterministas, rápidas y confiables en CI.

Cambios

Uso de jest.fn() para mockear PrismaService.
Tests de creación, lectura, paginación y manejo de errores (P2002, P2025, NotFoundException).
Limpieza de mocks con jest.resetAllMocks().
Sin accesos reales a BD.
