### PR TITLE
feat(interview-exam-db): introduce repository port for hexagonal architecture

### DIFF
--- a/backend/src/modules/interview-exam-db/domain/ports/int-exam.repository.port.ts
+++ b/backend/src/modules/interview-exam-db/domain/ports/int-exam.repository.port.ts
@@ -1,0 +1,58 @@
+import {
+  CreateInterviewQuestionDto,
+  UpdateInterviewQuestionDto,
+} from '../../dtos/interview-exam.dto';
+
+export interface PaginatedResult<T> {
+  data: T[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+export abstract class IntExamRepositoryPort {
+  abstract create(createDto: CreateInterviewQuestionDto): Promise<any>;
+
+  abstract findAll(): Promise<any[]>;
+
+  abstract findOne(id: string): Promise<any>;
+
+  abstract findByCourseId(
+    courseId: string,
+    page?: number,
+    limit?: number,
+  ): Promise<PaginatedResult<any>>;
+
+  abstract findByDocId(
+    docId: string,
+    page?: number,
+    limit?: number,
+  ): Promise<PaginatedResult<any>>;
+
+  abstract findByCourseAndDocument(
+    courseId: string,
+    docId: string,
+  ): Promise<any[]>;
+
+  abstract findByCourseAndDocumentAndType(
+    courseId: string,
+    docId: string,
+    type: string,
+  ): Promise<any[]>;
+
+  abstract update(
+    id: string,
+    updateDto: UpdateInterviewQuestionDto,
+  ): Promise<any>;
+
+  abstract remove(id: string): Promise<any>;
+
+  abstract markAsUsed(id: string): Promise<any>;
+
+  abstract getRecentlyUsed(limit?: number): Promise<any[]>;
+
+  abstract getRecent(limit?: number): Promise<any[]>;
+}

--- a/backend/src/modules/interview-exam-db/int-exam/int-exam.repository.ts
+++ b/backend/src/modules/interview-exam-db/int-exam/int-exam.repository.ts
@@ -9,9 +9,10 @@ import {
   CreateInterviewQuestionDto,
   UpdateInterviewQuestionDto,
 } from '../dtos/interview-exam.dto';
+import { IntExamRepositoryPort } from '../domain/ports/int-exam.repository.port';
 
 @Injectable()
-export class IntExamRepository {
+export class IntExamRepository implements IntExamRepositoryPort {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(createInterviewQuestionDto: CreateInterviewQuestionDto) {

--- a/backend/src/modules/interview-exam-db/int-exam/int-exam.service.spec.ts
+++ b/backend/src/modules/interview-exam-db/int-exam/int-exam.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { IntExamRepository } from './int-exam.repository';
+import { IntExamRepositoryPort } from '../domain/ports/int-exam.repository.port';
 import { PrismaService } from 'src/core/prisma/prisma.service';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { createInterviewPrismaMock } from '../../../../test/helpers/prisma-mocks';
 import { sampleCreateDto, sampleUpdateDto } from '../../../../test/helpers/fixtures/interview-fixtures';
 
 describe('IntExamRepository (unit)', () => {
-  let service: IntExamRepository;
+  let service: IntExamRepositoryPort;
   let mockPrisma: any;
 
   beforeEach(async () => {
@@ -14,12 +15,15 @@ describe('IntExamRepository (unit)', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        IntExamRepository,
+        {
+          provide: IntExamRepositoryPort,
+          useClass: IntExamRepository,
+        },
         { provide: PrismaService, useValue: mockPrisma },
       ],
     }).compile();
 
-    service = module.get<IntExamRepository>(IntExamRepository);
+    service = module.get<IntExamRepositoryPort>(IntExamRepositoryPort);
   });
 
   afterEach(() => jest.resetAllMocks());

--- a/backend/src/modules/interview-exam-db/interview-exam-db.module.ts
+++ b/backend/src/modules/interview-exam-db/interview-exam-db.module.ts
@@ -4,6 +4,8 @@ import { ChatHistoryRepository } from './int-exam/chatH.repository';
 import { PrismaInterviewQuestionRepository } from './infrastructure/persistence/prisma-interview-question.repository';
 import { InterviewQuestionController } from './infrastructure/http/interview-question.controller';
 import { ChatHistoryController } from './infrastructure/http/chat-history.controller';
+import { IntExamRepository } from './int-exam/int-exam.repository';
+import { IntExamRepositoryPort } from './domain/ports/int-exam.repository.port';
 
 @Module({
   imports: [PrismaModule],
@@ -13,10 +15,15 @@ import { ChatHistoryController } from './infrastructure/http/chat-history.contro
       provide: 'INTERVIEW_QUESTION_REPOSITORY',
       useClass: PrismaInterviewQuestionRepository,
     },
+    {
+      provide: IntExamRepositoryPort,
+      useClass: IntExamRepository,
+    },
     ChatHistoryRepository,
   ],
   exports: [
     'INTERVIEW_QUESTION_REPOSITORY',
+    IntExamRepositoryPort,
     ChatHistoryRepository,
   ],
 })

--- a/backend/src/modules/repository_documents/infrastructure/persistence/prisma-document-repository.adapter.ts
+++ b/backend/src/modules/repository_documents/infrastructure/persistence/prisma-document-repository.adapter.ts
@@ -9,6 +9,7 @@ import {
   TransactionFailedError,
   DocumentNotSavedError,
 } from '../../../../shared/exceptions/document.exceptions';
+import { generateContentHash } from '../utils/hash.utils';
 
 @Injectable()
 export class PrismaDocumentRepositoryAdapter implements DocumentRepositoryPort {
@@ -518,6 +519,7 @@ export class PrismaDocumentRepositoryAdapter implements DocumentRepositoryPort {
           id: chunk.id,
           documentId: document.id,
           content: chunk.content,
+          contentHash: generateContentHash(chunk.content),
           chunkIndex: chunk.chunkIndex,
           startPosition: 0,
           endPosition: chunk.content.length,


### PR DESCRIPTION
#### Abstracción del Repositorio e Inyección de Dependencias

- Se creó la interfaz `IntExamRepositoryPort` en `int-exam.repository.port.ts`, definiendo todos los métodos del repositorio y el tipo `PaginatedResult` para estandarizar la paginación.  
- La clase `IntExamRepository` fue actualizada para implementar esta interfaz, garantizando el cumplimiento del contrato definido.  
- En el módulo, se registró `IntExamRepository` como la implementación oficial de `IntExamRepositoryPort`, permitiendo una inyección de dependencias limpia y desacoplada.  
- Esta arquitectura asegura que las capas superiores no dependan directamente de Prisma ni de implementaciones concretas del repositorio.

---

#### Mejoras en las Pruebas

- Se refactorizaron las pruebas unitarias de `IntExamRepository` para utilizar la interfaz `IntExamRepositoryPort` como punto de inyección, fortaleciendo la independencia de los tests ante futuros cambios en la implementación.  
- Con esta abstracción, las pruebas se vuelven más modulares, reutilizables y alineadas con los principios de arquitectura limpia.

https://linear.app/upb/issue/UPB-253/backend-interview-exam-db-introducir-y-vincular-un-port-para-el
