### PR TITLE
refactor/error handling logs

### DIFF
--- a/backend/src/modules/interview-exam-db/infrastructure/persistence/repository-error.handler.ts
+++ b/backend/src/modules/interview-exam-db/infrastructure/persistence/repository-error.handler.ts
@@ -1,0 +1,25 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+export class RepositoryErrorHandler {
+  static handle(error: any, context: string): never {
+    const code = error?.code;
+
+    switch (code) {
+      case 'P2002':
+        throw new ConflictException(`${context}: registro duplicado.`);
+      case 'P2003':
+        throw new BadRequestException(`${context}: referencia inexistente.`);
+      case 'P2025':
+        throw new NotFoundException(`${context}: registro no encontrado.`);
+      default:
+        throw new InternalServerErrorException(
+          `${context}: error inesperado.`,
+        );
+    }
+  }
+}


### PR DESCRIPTION
Se estandarizó el manejo de errores y el uso de logs en los repositorios
src/modules/interview-exam-db/int-exam/*.repository.ts y chatH.repository.ts.

Antes se devolvían errores crudos de Prisma y se usaban console.log.
Ahora todos los repositorios usan el logger estándar del proyecto y devuelven excepciones controladas de NestJS.